### PR TITLE
feat: custom commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,14 @@
 version = 4
 
 [[package]]
+name = "custom_commands"
+version = "0.1.0"
+dependencies = [
+ "kc-osm",
+ "windows-core",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15,6 +23,7 @@ dependencies = [
  "kc-osm-proc-macros",
  "windows",
  "windows-core",
+ "windows-sys",
 ]
 
 [[package]]
@@ -167,6 +176,15 @@ name = "windows-strings"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,7 @@ version = "0.0.1"
 dependencies = [
  "bitflags",
  "kc-osm-proc-macros",
+ "thiserror",
  "windows",
  "windows-core",
  "windows-sys",
@@ -78,6 +79,26 @@ version = "0.1.0"
 dependencies = [
  "kc-osm",
  "windows-core",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
 name = "custom_commands"
 version = "0.1.0"
 dependencies = [
@@ -20,6 +26,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 name = "kc-osm"
 version = "0.0.1"
 dependencies = [
+ "bitflags",
  "kc-osm-proc-macros",
  "windows",
  "windows-core",

--- a/crates/kc-osm/Cargo.toml
+++ b/crates/kc-osm/Cargo.toml
@@ -12,3 +12,4 @@ windows = { version = "0.62.2", features = ["Win32_System_Com"] }
 windows-core = "0.62.2"
 windows-sys = { version = "0.61.2", features = ["Win32_System_LibraryLoader"] }
 kc-osm-proc-macros = { version = "0.0.1", path = "../kc-osm-proc-macros" }
+bitflags = "2.11.0"

--- a/crates/kc-osm/Cargo.toml
+++ b/crates/kc-osm/Cargo.toml
@@ -13,3 +13,4 @@ windows-core = "0.62.2"
 windows-sys = { version = "0.61.2", features = ["Win32_System_LibraryLoader"] }
 kc-osm-proc-macros = { version = "0.0.1", path = "../kc-osm-proc-macros" }
 bitflags = "2.11.0"
+thiserror = "2.0.18"

--- a/crates/kc-osm/Cargo.toml
+++ b/crates/kc-osm/Cargo.toml
@@ -10,4 +10,5 @@ description = "Helper library for writing Dark Engine object script modules (OSM
 [dependencies]
 windows = { version = "0.62.2", features = ["Win32_System_Com"] }
 windows-core = "0.62.2"
+windows-sys = { version = "0.61.2", features = ["Win32_System_LibraryLoader"] }
 kc-osm-proc-macros = { version = "0.0.1", path = "../kc-osm-proc-macros" }

--- a/crates/kc-osm/src/commands.rs
+++ b/crates/kc-osm/src/commands.rs
@@ -5,9 +5,23 @@ use std::{
     sync::{LazyLock, Mutex},
 };
 
+use bitflags::bitflags;
 use windows_sys::Win32::System::LibraryLoader::GetModuleHandleA;
 
 use crate::cstr_convert;
+
+bitflags! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    pub struct CommandContext: c_ulong {
+        const GAME_MODE = 0b00000001;
+        const BRUSH_EDIT = 0b00000010;
+        const OBJ_EDIT = 0b00000100;
+        const GAME_MODE2 = 0b00100000;
+
+        const EDITOR = Self::BRUSH_EDIT.bits() | Self::OBJ_EDIT.bits();
+        const ALL = !0;
+    }
+}
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -32,7 +46,7 @@ pub struct CommandInfo {
     pub name: String,
     pub type_: CommandType,
     pub comment: String,
-    pub contexts: u32,
+    pub contexts: CommandContext,
     pub unknown: i32,
 }
 
@@ -40,7 +54,7 @@ impl Display for CommandInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "('{}', {:?}, '{}', {}, {})",
+            "('{}', {:?}, '{}', {:?}, {})",
             self.name, self.type_, self.comment, self.contexts, self.unknown
         )
     }
@@ -53,7 +67,7 @@ pub struct Command {
     pub type_: CommandType,
     pub val: *const c_void,
     pub comment: *const c_char,
-    pub contexts: c_ulong,
+    pub contexts: CommandContext,
     pub unknown: c_int,
 }
 
@@ -62,7 +76,7 @@ impl Command {
         name: &str,
         help: &str,
         type_: CommandType,
-        contexts: u32,
+        contexts: CommandContext,
         func: *const c_void,
     ) -> Self {
         Self {

--- a/crates/kc-osm/src/commands.rs
+++ b/crates/kc-osm/src/commands.rs
@@ -1,0 +1,153 @@
+use std::{
+    ffi::{CString, c_char, c_int, c_ulong, c_void},
+    fmt::Display,
+    ptr::null,
+    sync::{LazyLock, Mutex},
+};
+
+use windows_sys::Win32::System::LibraryLoader::GetModuleHandleA;
+
+use crate::cstr_convert;
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub enum CommandType {
+    FuncVoid,
+    FuncBool,
+    FuncInt,
+    FuncFloat,
+    FuncDouble,
+    FuncString,
+    VarBool,
+    VarInt,
+    VarString,
+    VarIntArray,
+    VarFloat,
+    ToggleBool,
+    ToggleInt,
+}
+
+#[derive(Debug, Clone)]
+pub struct CommandInfo {
+    pub name: String,
+    pub type_: CommandType,
+    pub comment: String,
+    pub contexts: u32,
+    pub unknown: i32,
+}
+
+impl Display for CommandInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "('{}', {:?}, '{}', {}, {})",
+            self.name, self.type_, self.comment, self.contexts, self.unknown
+        )
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct Command {
+    pub name: *const c_char,
+    pub type_: CommandType,
+    pub val: *const c_void,
+    pub comment: *const c_char,
+    pub contexts: c_ulong,
+    pub unknown: c_int,
+}
+
+impl Command {
+    pub fn new(
+        name: &str,
+        help: &str,
+        type_: CommandType,
+        contexts: u32,
+        func: *const c_void,
+    ) -> Self {
+        Self {
+            name: CString::new(name).unwrap().into_raw(),
+            type_,
+            val: func,
+            comment: CString::new(help).unwrap().into_raw(),
+            contexts,
+            unknown: 0,
+        }
+    }
+}
+
+fn get_command_ptrs() -> (*mut c_int, *mut *const Command, *mut c_int) {
+    let base = unsafe { GetModuleHandleA(null()) } as u32;
+    let command_list_size_ptr = (base + 0x6809bc) as *mut c_int;
+    let command_list_ptr = (base + 0x6809c0) as *mut *const Command;
+    let command_count_ptr = (base + 0x680dc0) as *mut c_int;
+    (command_list_size_ptr, command_list_ptr, command_count_ptr)
+}
+
+pub fn get_all_command_infos<'a>() -> Vec<CommandInfo> {
+    let mut commands = vec![];
+    let (command_list_size_ptr, command_list_ptr, command_count_ptr) = get_command_ptrs();
+    unsafe {
+        for i in 0..*command_list_size_ptr {
+            let count = *command_count_ptr.offset(i as isize);
+            for j in 0..count {
+                let cmd = *(*command_list_ptr.offset(i as isize)).offset(j as isize);
+                commands.push(CommandInfo {
+                    name: cstr_convert(cmd.name),
+                    type_: cmd.type_,
+                    comment: cstr_convert(cmd.comment),
+                    contexts: cmd.contexts,
+                    unknown: cmd.unknown,
+                });
+            }
+        }
+    };
+
+    commands
+}
+
+pub(crate) fn register_command_set(cmds: &[Command]) {
+    let count = cmds.len() as i32;
+    if count <= 0 {
+        return;
+    }
+
+    let cmds_ptr = Box::leak(Box::new(cmds.to_vec())).as_ptr();
+    let (command_list_size_ptr, command_list_ptr, command_count_ptr) = get_command_ptrs();
+    unsafe {
+        let size_offset = (*command_list_size_ptr) as isize;
+        *command_list_ptr.offset(size_offset) = cmds_ptr;
+        *command_count_ptr.offset(size_offset) = count;
+        *command_list_size_ptr += 1;
+    };
+
+    let mut commands = COMMAND_SETS.lock().unwrap();
+    commands.push(cmds_ptr as usize);
+}
+
+pub(crate) fn deregister_command_sets() {
+    let commands = COMMAND_SETS.lock().unwrap();
+    let (command_list_size_ptr, command_list_ptr, command_count_ptr) = get_command_ptrs();
+    unsafe {
+        for cmd_set in commands.iter() {
+            let cmd_set_ptr = *cmd_set as *const Command;
+            let mut found = false;
+            for i in 0..*command_list_size_ptr {
+                if *command_list_ptr.offset(i as isize) == cmd_set_ptr {
+                    found = true;
+                }
+
+                if !found {
+                    continue;
+                }
+
+                // Shift everything afterwards down
+                *command_list_ptr.offset(i as isize) = *command_list_ptr.offset((i + 1) as isize);
+                *command_count_ptr.offset(i as isize) = *command_count_ptr.offset((i + 1) as isize);
+                *command_list_size_ptr -= 1;
+            }
+        }
+    };
+}
+
+static COMMAND_SETS: LazyLock<Mutex<Vec<usize>>> = LazyLock::new(|| Mutex::new(vec![]));

--- a/crates/kc-osm/src/commands.rs
+++ b/crates/kc-osm/src/commands.rs
@@ -149,6 +149,7 @@ pub(crate) fn deregister_command_sets() {
             for i in 0..*command_list_size_ptr {
                 if *command_list_ptr.offset(i as isize) == cmd_set_ptr {
                     found = true;
+                    *command_list_size_ptr -= 1;
                 }
 
                 if !found {
@@ -158,7 +159,6 @@ pub(crate) fn deregister_command_sets() {
                 // Shift everything afterwards down
                 *command_list_ptr.offset(i as isize) = *command_list_ptr.offset((i + 1) as isize);
                 *command_count_ptr.offset(i as isize) = *command_count_ptr.offset((i + 1) as isize);
-                *command_list_size_ptr -= 1;
             }
         }
     };

--- a/crates/kc-osm/src/commands.rs
+++ b/crates/kc-osm/src/commands.rs
@@ -8,7 +8,7 @@ use std::{
 use bitflags::bitflags;
 use windows_sys::Win32::System::LibraryLoader::GetModuleHandleA;
 
-use crate::cstr_convert;
+use crate::{cstr_convert, services};
 
 bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -120,14 +120,22 @@ pub fn get_all_command_infos<'a>() -> Vec<CommandInfo> {
     commands
 }
 
+const MAX_COMMAND_SETS: i32 = 256; // Checked that it's the same across versions in Ghidra
 pub(crate) fn register_command_set(cmds: &[Command]) {
+    let debug = &services().debug;
     let count = cmds.len() as i32;
     if count <= 0 {
+        debug.print("Cannot register empty command group.");
+        return;
+    }
+
+    let (command_list_size_ptr, command_list_ptr, command_count_ptr) = get_command_ptrs();
+    if unsafe { *command_list_size_ptr } >= MAX_COMMAND_SETS {
+        debug.print("Cannot register command group. Max command groups reached.");
         return;
     }
 
     let cmds_ptr = Box::leak(Box::new(cmds.to_vec())).as_ptr();
-    let (command_list_size_ptr, command_list_ptr, command_count_ptr) = get_command_ptrs();
     unsafe {
         let size_offset = (*command_list_size_ptr) as isize;
         *command_list_ptr.offset(size_offset) = cmds_ptr;

--- a/crates/kc-osm/src/commands.rs
+++ b/crates/kc-osm/src/commands.rs
@@ -104,6 +104,15 @@ impl Command {
 fn get_command_ptrs() -> Option<(*mut c_int, *mut *const Command, *mut c_int)> {
     let version = &services().version;
     let offsets = match (version.get_version(), version.is_editor() != 0) {
+        ((1, 19), true) => (0x5f86fc, 0x5f8700, 0x5f8b00),
+        ((1, 20), true) => (0x6023bc, 0x6023c0, 0x6027c0),
+        ((1, 21), true) => (0x6033bc, 0x6033c0, 0x6037c0),
+        ((1, 22), true) => (0x61865c, 0x618660, 0x618a60),
+        ((1, 23), true) => (0x6269bc, 0x6269c0, 0x626dc0),
+        ((1, 24), true) => (0x6279bc, 0x6279c0, 0x627dc0),
+        ((1, 25), true) => (0x629abc, 0x629ac0, 0x629ec0),
+        ((1, 26), true) => (0x62a0dc, 0x62a0e0, 0x62a4e0),
+        ((1, 27), true) => (0x62e17c, 0x62e180, 0x62e580),
         ((1, 28), true) => (0x6809bc, 0x6809c0, 0x680dc0),
         _ => return None,
     };

--- a/crates/kc-osm/src/commands.rs
+++ b/crates/kc-osm/src/commands.rs
@@ -6,9 +6,20 @@ use std::{
 };
 
 use bitflags::bitflags;
+use thiserror::Error;
 use windows_sys::Win32::System::LibraryLoader::GetModuleHandleA;
 
 use crate::{cstr_convert, services};
+
+#[derive(Error, Debug)]
+pub enum CommandRegisterError {
+    #[error("Cannot register empty command group.")]
+    EmptySet,
+    #[error("Max command groups reached.")]
+    SetLimitReached,
+    #[error("Unsupported engine version.")]
+    UnsupportedEngineVersion,
+}
 
 bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -90,86 +101,93 @@ impl Command {
     }
 }
 
-fn get_command_ptrs() -> (*mut c_int, *mut *const Command, *mut c_int) {
+fn get_command_ptrs() -> Option<(*mut c_int, *mut *const Command, *mut c_int)> {
+    let version = &services().version;
+    let offsets = match (version.get_version(), version.is_editor() != 0) {
+        ((1, 28), true) => (0x6809bc, 0x6809c0, 0x680dc0),
+        _ => return None,
+    };
+
     let base = unsafe { GetModuleHandleA(null()) } as u32;
-    let command_list_size_ptr = (base + 0x6809bc) as *mut c_int;
-    let command_list_ptr = (base + 0x6809c0) as *mut *const Command;
-    let command_count_ptr = (base + 0x680dc0) as *mut c_int;
-    (command_list_size_ptr, command_list_ptr, command_count_ptr)
+    let set_count_ptr = (base + offsets.0) as *mut c_int;
+    let sets_ptr = (base + offsets.1) as *mut *const Command;
+    let cmd_count_ptr = (base + offsets.2) as *mut c_int;
+    Some((set_count_ptr, sets_ptr, cmd_count_ptr))
 }
 
 pub fn get_all_command_infos<'a>() -> Vec<CommandInfo> {
     let mut commands = vec![];
-    let (command_list_size_ptr, command_list_ptr, command_count_ptr) = get_command_ptrs();
-    unsafe {
-        for i in 0..*command_list_size_ptr {
-            let count = *command_count_ptr.offset(i as isize);
-            for j in 0..count {
-                let cmd = *(*command_list_ptr.offset(i as isize)).offset(j as isize);
-                commands.push(CommandInfo {
-                    name: cstr_convert(cmd.name),
-                    type_: cmd.type_,
-                    comment: cstr_convert(cmd.comment),
-                    contexts: cmd.contexts,
-                    unknown: cmd.unknown,
-                });
+    if let Some((set_count_ptr, sets_ptr, cmd_count_ptr)) = get_command_ptrs() {
+        unsafe {
+            for i in 0..*set_count_ptr {
+                let count = *cmd_count_ptr.offset(i as isize);
+                for j in 0..count {
+                    let cmd = *(*sets_ptr.offset(i as isize)).offset(j as isize);
+                    commands.push(CommandInfo {
+                        name: cstr_convert(cmd.name),
+                        type_: cmd.type_,
+                        comment: cstr_convert(cmd.comment),
+                        contexts: cmd.contexts,
+                        unknown: cmd.unknown,
+                    });
+                }
             }
-        }
-    };
+        };
+    }
 
     commands
 }
 
 const MAX_COMMAND_SETS: i32 = 256; // Checked that it's the same across versions in Ghidra
-pub(crate) fn register_command_set(cmds: &[Command]) {
-    let debug = &services().debug;
+pub(crate) fn register_command_set(cmds: &[Command]) -> Result<(), CommandRegisterError> {
     let count = cmds.len() as i32;
     if count <= 0 {
-        debug.print("Cannot register empty command group.");
-        return;
+        return Err(CommandRegisterError::EmptySet);
     }
 
-    let (command_list_size_ptr, command_list_ptr, command_count_ptr) = get_command_ptrs();
-    if unsafe { *command_list_size_ptr } >= MAX_COMMAND_SETS {
-        debug.print("Cannot register command group. Max command groups reached.");
-        return;
+    if let Some((set_count_ptr, sets_ptr, cmd_count_ptr)) = get_command_ptrs() {
+        if unsafe { *set_count_ptr } >= MAX_COMMAND_SETS {
+            return Err(CommandRegisterError::SetLimitReached);
+        }
+
+        let cmds_ptr = Box::leak(Box::new(cmds.to_vec())).as_ptr();
+        unsafe {
+            let size_offset = (*set_count_ptr) as isize;
+            *sets_ptr.offset(size_offset) = cmds_ptr;
+            *cmd_count_ptr.offset(size_offset) = count;
+            *set_count_ptr += 1;
+        };
+
+        COMMAND_SETS.lock().unwrap().push(cmds_ptr as usize);
+        return Ok(());
     }
 
-    let cmds_ptr = Box::leak(Box::new(cmds.to_vec())).as_ptr();
-    unsafe {
-        let size_offset = (*command_list_size_ptr) as isize;
-        *command_list_ptr.offset(size_offset) = cmds_ptr;
-        *command_count_ptr.offset(size_offset) = count;
-        *command_list_size_ptr += 1;
-    };
-
-    let mut commands = COMMAND_SETS.lock().unwrap();
-    commands.push(cmds_ptr as usize);
+    return Err(CommandRegisterError::UnsupportedEngineVersion);
 }
 
 pub(crate) fn deregister_command_sets() {
-    let commands = COMMAND_SETS.lock().unwrap();
-    let (command_list_size_ptr, command_list_ptr, command_count_ptr) = get_command_ptrs();
-    unsafe {
-        for cmd_set in commands.iter() {
-            let cmd_set_ptr = *cmd_set as *const Command;
-            let mut found = false;
-            for i in 0..*command_list_size_ptr {
-                if *command_list_ptr.offset(i as isize) == cmd_set_ptr {
-                    found = true;
-                    *command_list_size_ptr -= 1;
-                }
+    if let Some((set_count_ptr, sets_ptr, cmd_count_ptr)) = get_command_ptrs() {
+        unsafe {
+            for cmd_set in COMMAND_SETS.lock().unwrap().iter() {
+                let cmd_set_ptr = *cmd_set as *const Command;
+                let mut found = false;
+                for i in 0..*set_count_ptr {
+                    if *sets_ptr.offset(i as isize) == cmd_set_ptr {
+                        found = true;
+                        *set_count_ptr -= 1;
+                    }
 
-                if !found {
-                    continue;
-                }
+                    if !found {
+                        continue;
+                    }
 
-                // Shift everything afterwards down
-                *command_list_ptr.offset(i as isize) = *command_list_ptr.offset((i + 1) as isize);
-                *command_count_ptr.offset(i as isize) = *command_count_ptr.offset((i + 1) as isize);
+                    // Shift everything afterwards down
+                    *sets_ptr.offset(i as isize) = *sets_ptr.offset((i + 1) as isize);
+                    *cmd_count_ptr.offset(i as isize) = *cmd_count_ptr.offset((i + 1) as isize);
+                }
             }
-        }
-    };
+        };
+    }
 }
 
 static COMMAND_SETS: LazyLock<Mutex<Vec<usize>>> = LazyLock::new(|| Mutex::new(vec![]));

--- a/crates/kc-osm/src/lib.rs
+++ b/crates/kc-osm/src/lib.rs
@@ -8,7 +8,9 @@ use std::{
     ptr::null,
 };
 
-pub use crate::commands::{Command, CommandContext, CommandType, get_all_command_infos};
+pub use crate::commands::{
+    Command, CommandContext, CommandRegisterError, CommandType, get_all_command_infos,
+};
 use crate::commands::{deregister_command_sets, register_command_set};
 pub use crate::services::*;
 pub use kc_osm_proc_macros::dark_script;
@@ -210,8 +212,11 @@ impl ScriptModule {
     }
 
     /// Registers custom commands that can be ran in engine. Multiple groups of commands can be registers. All command groups are unregistered when the module is dropped.
-    pub fn register_commands(&self, cmds: &[Command]) {
-        register_command_set(cmds);
+    pub fn register_commands(
+        &self,
+        cmds: &[Command],
+    ) -> std::result::Result<(), CommandRegisterError> {
+        register_command_set(cmds)
     }
 
     /// # Safety
@@ -299,7 +304,7 @@ extern "stdcall" fn ScriptModuleInit(
         match module_init(&mut test_mod) {
             Ok(_) => test_mod.register(out_mod).into(),
             Err(e) => {
-                services().debug.print(e);
+                services().debug.print(&e);
                 false.into()
             }
         }
@@ -307,5 +312,5 @@ extern "stdcall" fn ScriptModuleInit(
 }
 
 unsafe extern "Rust" {
-    fn module_init(module: &mut ScriptModule) -> std::result::Result<(), &'static str>;
+    fn module_init(module: &mut ScriptModule) -> std::result::Result<(), String>;
 }

--- a/crates/kc-osm/src/lib.rs
+++ b/crates/kc-osm/src/lib.rs
@@ -8,7 +8,7 @@ use std::{
     ptr::null,
 };
 
-pub use crate::commands::{Command, CommandType, get_all_command_infos};
+pub use crate::commands::{Command, CommandContext, CommandType, get_all_command_infos};
 use crate::commands::{deregister_command_sets, register_command_set};
 pub use crate::services::*;
 pub use kc_osm_proc_macros::dark_script;

--- a/crates/kc-osm/src/lib.rs
+++ b/crates/kc-osm/src/lib.rs
@@ -1,3 +1,4 @@
+mod commands;
 mod malloc;
 mod services;
 
@@ -7,6 +8,8 @@ use std::{
     ptr::null,
 };
 
+pub use crate::commands::{Command, CommandType, get_all_command_infos};
+use crate::commands::{deregister_command_sets, register_command_set};
 pub use crate::services::*;
 pub use kc_osm_proc_macros::dark_script;
 pub use windows::{Win32::System::Com::IMalloc, core::*};
@@ -206,6 +209,11 @@ impl ScriptModule {
         self.classes.push(T::get_desc(self.name.to_str().unwrap()));
     }
 
+    /// Registers custom commands that can be ran in engine. Multiple groups of commands can be registers. All command groups are unregistered when the module is dropped.
+    pub fn register_commands(&self, cmds: &[Command]) {
+        register_command_set(cmds);
+    }
+
     /// # Safety
     ///
     /// `out_mod` must be a non-null, valid pointer for writing an interface pointer.
@@ -255,6 +263,24 @@ where
 {
     fn get_desc(mod_name: &str) -> sScrClassDesc;
     extern "C" fn factory(_name: *const c_char, _id: c_int) -> *mut IScript;
+}
+
+pub fn cstr_convert(val: *const c_char) -> String {
+    if val.is_null() {
+        return "".to_owned();
+    }
+    unsafe { CStr::from_ptr(val).to_string_lossy().into_owned() }
+}
+
+#[unsafe(no_mangle)]
+#[allow(non_snake_case, unused_variables)]
+extern "system" fn DllMain(dll_module: u32, call_reason: u32, _: *mut ()) -> bool {
+    match call_reason {
+        0 => deregister_command_sets(),
+        _ => (),
+    }
+
+    true
 }
 
 #[unsafe(no_mangle)]

--- a/examples/custom_commands/Cargo.toml
+++ b/examples/custom_commands/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "custom_commands"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type=["cdylib"]
+
+[dependencies]
+kc-osm = { path = "../../crates/kc-osm" }
+windows-core = "0.62.2"
+windows-sys = { version = "0.61.2", features = ["Win32_System_LibraryLoader"] }

--- a/examples/custom_commands/Cargo.toml
+++ b/examples/custom_commands/Cargo.toml
@@ -9,4 +9,3 @@ crate-type=["cdylib"]
 [dependencies]
 kc-osm = { path = "../../crates/kc-osm" }
 windows-core = "0.62.2"
-windows-sys = { version = "0.61.2", features = ["Win32_System_LibraryLoader"] }

--- a/examples/custom_commands/src/lib.rs
+++ b/examples/custom_commands/src/lib.rs
@@ -9,6 +9,13 @@ use std::{
 use kc_osm::*;
 use windows_sys::Win32::System::LibraryLoader::GetModuleHandleA;
 
+fn cstr_convert(val: *const c_char) -> String {
+    if val == null() {
+        return "".to_owned();
+    }
+    unsafe { CStr::from_ptr(val).to_string_lossy().into_owned() }
+}
+
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct Command {
@@ -22,16 +29,8 @@ pub struct Command {
 
 impl Display for Command {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let name = if self.name == null() {
-            "".to_owned()
-        } else {
-            unsafe { CStr::from_ptr(self.name).to_string_lossy().into_owned() }
-        };
-        let comment = if self.comment == null() {
-            "".to_owned()
-        } else {
-            unsafe { CStr::from_ptr(self.comment).to_string_lossy().into_owned() }
-        };
+        let name = cstr_convert(self.name);
+        let comment = cstr_convert(self.comment);
         write!(
             f,
             "('{}', {}, fn_ptr: {:?}, '{}', {}, {})",
@@ -116,6 +115,11 @@ pub extern "C" fn print_shit() {
     services.debug.print("Wow this is my custom command.");
 }
 
+pub extern "C" fn echo(val: *const c_char) {
+    let msg = cstr_convert(val);
+    services().debug.print(&msg);
+}
+
 #[unsafe(no_mangle)]
 pub extern "Rust" fn module_init(_: &mut ScriptModule) -> Result<(), &'static str> {
     let cmds = Box::new([
@@ -133,11 +137,17 @@ pub extern "Rust" fn module_init(_: &mut ScriptModule) -> Result<(), &'static st
             0xffffffff,
             log_cmds as *const c_void,
         ),
+        build_command(
+            "jecho",
+            "Prints whatever the input string was to mono",
+            5,
+            0xffffffff,
+            echo as *const c_void,
+        ),
     ]);
     let cmds_ptr = Box::into_raw(cmds) as *const Command;
 
-    register_command_set(cmds_ptr, 2);
-    // log_cmds();
+    register_command_set(cmds_ptr, 3);
 
     Ok(())
 }

--- a/examples/custom_commands/src/lib.rs
+++ b/examples/custom_commands/src/lib.rs
@@ -1,0 +1,86 @@
+use std::{
+    ffi::{CString, c_char, c_int, c_ulong, c_void},
+    mem::transmute,
+    ptr::null,
+    result::Result,
+};
+
+use kc_osm::*;
+use windows_sys::Win32::System::LibraryLoader::GetModuleHandleA;
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct Command {
+    pub name: *const c_char,
+    pub type_: c_int,
+    pub val: *const c_void,
+    pub comment: *const c_char,
+    pub contexts: c_ulong,
+}
+
+pub fn build_command(
+    name: &str,
+    help: &str,
+    type_: i32,
+    contexts: u32,
+    val: *const c_void,
+) -> Command {
+    Command {
+        name: CString::new(name).unwrap().into_raw(),
+        type_,
+        val,
+        comment: CString::new(help).unwrap().into_raw(),
+        contexts,
+    }
+}
+
+pub fn register_command_set(cmds_ptr: *const Command, count: c_int) {
+    if count <= 0 {
+        return;
+    }
+
+    const COMMAND_LIST_SIZE_OFFSET: u32 = 0x6809bc;
+    const COMMAND_LIST_OFFSET: u32 = 0x6809c0;
+    const COMMAND_COUNT_OFFSET: u32 = 0x680dc0;
+    let base = unsafe { GetModuleHandleA(null()) } as u32;
+
+    let command_list_size_ptr: *mut c_int = unsafe { transmute(base + COMMAND_LIST_SIZE_OFFSET) };
+    let command_list_ptr: *mut *const Command = unsafe { transmute(base + COMMAND_LIST_OFFSET) };
+    let command_count_ptr: *mut c_int = unsafe { transmute(base + COMMAND_COUNT_OFFSET) };
+
+    unsafe {
+        println!("Command list size: {}", *command_list_size_ptr);
+        let size_offset = (*command_list_size_ptr) as isize;
+        let set_ptr = command_list_ptr.offset(size_offset);
+        *set_ptr = cmds_ptr;
+        let count_ptr = command_count_ptr.offset(size_offset);
+        *count_ptr = count;
+        *command_list_size_ptr = *command_list_size_ptr + 1;
+        println!("Command list size: {}", *command_list_size_ptr);
+
+        let cmd = *cmds_ptr;
+        println!("Registered Cmd: {:?}", cmd);
+    };
+}
+
+pub extern "C" fn print_shit() {
+    let services = services();
+    services.debug.print("Wow this is my custom command.");
+}
+
+#[unsafe(no_mangle)]
+pub extern "Rust" fn module_init(_: &mut ScriptModule) -> Result<(), &'static str> {
+    let cmds = Box::new([build_command(
+        "jay_custom_command",
+        "This is a custom command that does *something* epic",
+        0,
+        0xffffffff,
+        print_shit as *const c_void,
+    )]);
+    let cmds_ptr = Box::leak(cmds) as *const Command;
+
+    register_command_set(cmds_ptr, 1);
+
+    println!("shit head");
+    Ok(())
+}

--- a/examples/custom_commands/src/lib.rs
+++ b/examples/custom_commands/src/lib.rs
@@ -56,10 +56,13 @@ pub fn build_command(
     }
 }
 
-pub fn register_command_set(cmds_ptr: *const Command, count: c_int) {
+pub fn register_command_set(cmds: &[Command]) {
+    let count = cmds.len() as i32;
     if count <= 0 {
         return;
     }
+
+    let cmds_ptr = Box::leak(Box::new(cmds.to_vec())).as_ptr();
 
     const COMMAND_LIST_SIZE_OFFSET: u32 = 0x6809bc;
     const COMMAND_LIST_OFFSET: u32 = 0x6809c0;
@@ -122,7 +125,7 @@ pub extern "C" fn echo(val: *const c_char) {
 
 #[unsafe(no_mangle)]
 pub extern "Rust" fn module_init(_: &mut ScriptModule) -> Result<(), &'static str> {
-    let cmds = Box::new([
+    register_command_set(&[
         build_command(
             "jay_custom_command",
             "This is a custom command that does *something* epic",
@@ -145,9 +148,6 @@ pub extern "Rust" fn module_init(_: &mut ScriptModule) -> Result<(), &'static st
             echo as *const c_void,
         ),
     ]);
-    let cmds_ptr = Box::into_raw(cmds) as *const Command;
-
-    register_command_set(cmds_ptr, 3);
 
     Ok(())
 }

--- a/examples/custom_commands/src/lib.rs
+++ b/examples/custom_commands/src/lib.rs
@@ -1,13 +1,18 @@
 use std::{
     ffi::{CStr, CString, c_char, c_int, c_ulong, c_void},
     fmt::Display,
-    mem::transmute,
     ptr::null,
     result::Result,
+    sync::{LazyLock, Mutex},
 };
 
 use kc_osm::*;
 use windows_sys::Win32::System::LibraryLoader::GetModuleHandleA;
+
+#[derive(Debug, Default)]
+struct State {
+    commands: Vec<usize>,
+}
 
 fn cstr_convert(val: *const c_char) -> String {
     if val.is_null() {
@@ -98,6 +103,34 @@ pub fn register_command_set(cmds: &[Command]) {
         *command_count_ptr.offset(size_offset) = count;
         *command_list_size_ptr += 1;
     };
+
+    let mut state = get_state();
+    state.commands.push(cmds_ptr as usize);
+}
+
+pub fn deregister_command_sets() {
+    let state = get_state();
+    let (command_list_size_ptr, command_list_ptr, command_count_ptr) = get_command_ptrs();
+    unsafe {
+        for cmd_set in &state.commands {
+            let cmd_set_ptr = *cmd_set as *const Command;
+            let mut found = false;
+            for i in 0..*command_list_size_ptr {
+                if *command_list_ptr.offset(i as isize) == cmd_set_ptr {
+                    found = true;
+                }
+
+                if !found {
+                    continue;
+                }
+
+                // Shift everything afterwards down
+                *command_list_ptr.offset(i as isize) = *command_list_ptr.offset((i + 1) as isize);
+                *command_count_ptr.offset(i as isize) = *command_count_ptr.offset((i + 1) as isize);
+                *command_list_size_ptr -= 1;
+            }
+        }
+    };
 }
 
 pub extern "C" fn log_cmds() {
@@ -153,4 +186,21 @@ pub extern "Rust" fn module_init(_: &mut ScriptModule) -> Result<(), &'static st
     ]);
 
     Ok(())
+}
+
+static STATE: LazyLock<Mutex<State>> = LazyLock::new(|| Mutex::new(State { commands: vec![] }));
+
+fn get_state<'a>() -> std::sync::MutexGuard<'a, State> {
+    STATE.lock().unwrap()
+}
+
+#[unsafe(no_mangle)]
+#[allow(non_snake_case, unused_variables)]
+extern "system" fn DllMain(dll_module: u32, call_reason: u32, _: *mut ()) -> bool {
+    match call_reason {
+        0 => deregister_command_sets(),
+        _ => (),
+    }
+
+    true
 }

--- a/examples/custom_commands/src/lib.rs
+++ b/examples/custom_commands/src/lib.rs
@@ -77,14 +77,10 @@ impl Display for Command {
 }
 
 pub fn get_command_ptrs() -> (*mut c_int, *mut *const Command, *mut c_int) {
-    const COMMAND_LIST_SIZE_OFFSET: u32 = 0x6809bc;
-    const COMMAND_LIST_OFFSET: u32 = 0x6809c0;
-    const COMMAND_COUNT_OFFSET: u32 = 0x680dc0;
     let base = unsafe { GetModuleHandleA(null()) } as u32;
-
-    let command_list_size_ptr: *mut c_int = unsafe { transmute(base + COMMAND_LIST_SIZE_OFFSET) };
-    let command_list_ptr: *mut *const Command = unsafe { transmute(base + COMMAND_LIST_OFFSET) };
-    let command_count_ptr: *mut c_int = unsafe { transmute(base + COMMAND_COUNT_OFFSET) };
+    let command_list_size_ptr = (base + 0x6809bc) as *mut c_int;
+    let command_list_ptr = (base + 0x6809c0) as *mut *const Command;
+    let command_count_ptr = (base + 0x680dc0) as *mut c_int;
     (command_list_size_ptr, command_list_ptr, command_count_ptr)
 }
 

--- a/examples/custom_commands/src/lib.rs
+++ b/examples/custom_commands/src/lib.rs
@@ -16,6 +16,7 @@ pub struct Command {
     pub val: *const c_void,
     pub comment: *const c_char,
     pub contexts: c_ulong,
+    unknown: c_int,
 }
 
 pub fn build_command(
@@ -31,6 +32,7 @@ pub fn build_command(
         val,
         comment: CString::new(help).unwrap().into_raw(),
         contexts,
+        unknown: 0,
     }
 }
 
@@ -70,16 +72,25 @@ pub extern "C" fn print_shit() {
 
 #[unsafe(no_mangle)]
 pub extern "Rust" fn module_init(_: &mut ScriptModule) -> Result<(), &'static str> {
-    let cmds = Box::new([build_command(
-        "jay_custom_command",
-        "This is a custom command that does *something* epic",
-        0,
-        0xffffffff,
-        print_shit as *const c_void,
-    )]);
-    let cmds_ptr = Box::leak(cmds) as *const Command;
+    let cmds = Box::new([
+        build_command(
+            "jay_custom_command",
+            "This is a custom command that does *something* epic",
+            0,
+            0xffffffff,
+            print_shit as *const c_void,
+        ),
+        build_command(
+            "jay_custom_command2",
+            "seccond command!",
+            0,
+            0xffffffff,
+            print_shit as *const c_void,
+        ),
+    ]);
+    let cmds_ptr = Box::into_raw(cmds) as *const Command;
 
-    register_command_set(cmds_ptr, 1);
+    register_command_set(cmds_ptr, 2);
 
     println!("shit head");
     Ok(())

--- a/examples/custom_commands/src/lib.rs
+++ b/examples/custom_commands/src/lib.rs
@@ -18,9 +18,27 @@ fn cstr_convert(val: *const c_char) -> String {
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub enum CommandType {
+    FuncVoid,
+    FuncBool,
+    FuncInt,
+    FuncFloat,
+    FuncDouble,
+    FuncString,
+    VarBool,
+    VarInt,
+    VarString,
+    VarIntArray,
+    VarFloat,
+    ToggleBool,
+    ToggleInt,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct Command {
     pub name: *const c_char,
-    pub type_: c_int,
+    pub type_: CommandType,
     pub val: *const c_void,
     pub comment: *const c_char,
     pub contexts: c_ulong,
@@ -28,7 +46,13 @@ pub struct Command {
 }
 
 impl Command {
-    pub fn new(name: &str, help: &str, type_: i32, contexts: u32, func: *const c_void) -> Self {
+    pub fn new(
+        name: &str,
+        help: &str,
+        type_: CommandType,
+        contexts: u32,
+        func: *const c_void,
+    ) -> Self {
         Self {
             name: CString::new(name).unwrap().into_raw(),
             type_,
@@ -46,7 +70,7 @@ impl Display for Command {
         let comment = cstr_convert(self.comment);
         write!(
             f,
-            "('{}', {}, fn_ptr: {:?}, '{}', {}, {})",
+            "('{}', {:?}, fn_ptr: {:?}, '{}', {}, {})",
             name, self.type_, self.val, comment, self.contexts, self.unknown
         )
     }
@@ -125,21 +149,21 @@ pub extern "Rust" fn module_init(_: &mut ScriptModule) -> Result<(), &'static st
         Command::new(
             "jay_custom_command",
             "This is a custom command that does *something* epic",
-            0,
+            CommandType::FuncVoid,
             0xffffffff,
             print_shit as *const c_void,
         ),
         Command::new(
             "log_cmds",
             "Output more detailed information for every command in dromed",
-            0,
+            CommandType::FuncVoid,
             0xffffffff,
             log_cmds as *const c_void,
         ),
         Command::new(
             "jecho",
             "Prints whatever the input string was to mono",
-            5,
+            CommandType::FuncString,
             0xffffffff,
             echo as *const c_void,
         ),

--- a/examples/custom_commands/src/lib.rs
+++ b/examples/custom_commands/src/lib.rs
@@ -86,7 +86,7 @@ pub fn register_command_set(cmds_ptr: *const Command, count: c_int) {
     };
 }
 
-pub fn log_cmds() {
+pub extern "C" fn log_cmds() {
     let debug = &services().debug;
 
     const COMMAND_LIST_SIZE_OFFSET: u32 = 0x6809bc;
@@ -127,17 +127,17 @@ pub extern "Rust" fn module_init(_: &mut ScriptModule) -> Result<(), &'static st
             print_shit as *const c_void,
         ),
         build_command(
-            "jay_custom_command2",
-            "seccond command!",
+            "log_cmds",
+            "Output more detailed information for every command in dromed",
             0,
             0xffffffff,
-            print_shit as *const c_void,
+            log_cmds as *const c_void,
         ),
     ]);
     let cmds_ptr = Box::into_raw(cmds) as *const Command;
 
     register_command_set(cmds_ptr, 2);
-    log_cmds();
+    // log_cmds();
 
     Ok(())
 }

--- a/examples/custom_commands/src/lib.rs
+++ b/examples/custom_commands/src/lib.rs
@@ -12,11 +12,6 @@ pub extern "C" fn log_cmds() {
     }
 }
 
-pub extern "C" fn print_shit() {
-    let services = services();
-    services.debug.print("Wow this is my custom command.");
-}
-
 pub extern "C" fn echo(val: *const c_char) {
     let msg = cstr_convert(val);
     services().debug.print(&msg);
@@ -25,13 +20,6 @@ pub extern "C" fn echo(val: *const c_char) {
 #[unsafe(no_mangle)]
 pub extern "Rust" fn module_init(module: &mut ScriptModule) -> Result<(), &'static str> {
     module.register_commands(&[
-        Command::new(
-            "jay_custom_command",
-            "This is a custom command that does *something* epic",
-            CommandType::FuncVoid,
-            0xffffffff,
-            print_shit as *const c_void,
-        ),
         Command::new(
             "log_cmds",
             "Output more detailed information for every command in dromed",

--- a/examples/custom_commands/src/lib.rs
+++ b/examples/custom_commands/src/lib.rs
@@ -1,5 +1,6 @@
 use std::{
-    ffi::{CString, c_char, c_int, c_ulong, c_void},
+    ffi::{CStr, CString, c_char, c_int, c_ulong, c_void},
+    fmt::Display,
     mem::transmute,
     ptr::null,
     result::Result,
@@ -17,6 +18,26 @@ pub struct Command {
     pub comment: *const c_char,
     pub contexts: c_ulong,
     unknown: c_int,
+}
+
+impl Display for Command {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = if self.name == null() {
+            "".to_owned()
+        } else {
+            unsafe { CStr::from_ptr(self.name).to_string_lossy().into_owned() }
+        };
+        let comment = if self.comment == null() {
+            "".to_owned()
+        } else {
+            unsafe { CStr::from_ptr(self.comment).to_string_lossy().into_owned() }
+        };
+        write!(
+            f,
+            "('{}', {}, fn_ptr: {:?}, '{}', {}, {})",
+            name, self.type_, self.val, comment, self.contexts, self.unknown
+        )
+    }
 }
 
 pub fn build_command(
@@ -65,6 +86,31 @@ pub fn register_command_set(cmds_ptr: *const Command, count: c_int) {
     };
 }
 
+pub fn log_cmds() {
+    let debug = &services().debug;
+
+    const COMMAND_LIST_SIZE_OFFSET: u32 = 0x6809bc;
+    const COMMAND_LIST_OFFSET: u32 = 0x6809c0;
+    const COMMAND_COUNT_OFFSET: u32 = 0x680dc0;
+    let base = unsafe { GetModuleHandleA(null()) } as u32;
+
+    let command_list_size_ptr: *mut c_int = unsafe { transmute(base + COMMAND_LIST_SIZE_OFFSET) };
+    let command_list_ptr: *mut *const Command = unsafe { transmute(base + COMMAND_LIST_OFFSET) };
+    let command_count_ptr: *mut c_int = unsafe { transmute(base + COMMAND_COUNT_OFFSET) };
+
+    unsafe {
+        for i in 0..(*command_list_size_ptr) {
+            let count = *(command_count_ptr.offset(i as isize));
+            debug.print(&format!("Command set contains {count} commands"));
+            for j in 0..count {
+                let set_ptr = command_list_ptr.offset(i as isize);
+                let cmd = *((*set_ptr).offset(j as isize));
+                debug.print(&format!("Command: {cmd}"));
+            }
+        }
+    };
+}
+
 pub extern "C" fn print_shit() {
     let services = services();
     services.debug.print("Wow this is my custom command.");
@@ -91,7 +137,7 @@ pub extern "Rust" fn module_init(_: &mut ScriptModule) -> Result<(), &'static st
     let cmds_ptr = Box::into_raw(cmds) as *const Command;
 
     register_command_set(cmds_ptr, 2);
+    log_cmds();
 
-    println!("shit head");
     Ok(())
 }

--- a/examples/custom_commands/src/lib.rs
+++ b/examples/custom_commands/src/lib.rs
@@ -18,23 +18,23 @@ pub extern "C" fn echo(val: *const c_char) {
 }
 
 #[unsafe(no_mangle)]
-pub extern "Rust" fn module_init(module: &mut ScriptModule) -> Result<(), &'static str> {
-    module.register_commands(&[
-        Command::new(
-            "log_cmds",
-            "Output more detailed information for every command in dromed",
-            CommandType::FuncVoid,
-            CommandContext::EDITOR,
-            log_cmds as *const c_void,
-        ),
-        Command::new(
-            "jecho",
-            "Prints whatever the input string was to mono",
-            CommandType::FuncString,
-            CommandContext::ALL,
-            echo as *const c_void,
-        ),
-    ]);
-
-    Ok(())
+pub extern "Rust" fn module_init(module: &mut ScriptModule) -> Result<(), String> {
+    module
+        .register_commands(&[
+            Command::new(
+                "log_cmds",
+                "Output more detailed information for every command in dromed",
+                CommandType::FuncVoid,
+                CommandContext::EDITOR,
+                log_cmds as *const c_void,
+            ),
+            Command::new(
+                "jecho",
+                "Prints whatever the input string was to mono",
+                CommandType::FuncString,
+                CommandContext::ALL,
+                echo as *const c_void,
+            ),
+        ])
+        .map_err(|e| format!("{e}"))
 }

--- a/examples/custom_commands/src/lib.rs
+++ b/examples/custom_commands/src/lib.rs
@@ -10,7 +10,7 @@ use kc_osm::*;
 use windows_sys::Win32::System::LibraryLoader::GetModuleHandleA;
 
 fn cstr_convert(val: *const c_char) -> String {
-    if val == null() {
+    if val.is_null() {
         return "".to_owned();
     }
     unsafe { CStr::from_ptr(val).to_string_lossy().into_owned() }
@@ -76,6 +76,18 @@ impl Display for Command {
     }
 }
 
+pub fn get_command_ptrs() -> (*mut c_int, *mut *const Command, *mut c_int) {
+    const COMMAND_LIST_SIZE_OFFSET: u32 = 0x6809bc;
+    const COMMAND_LIST_OFFSET: u32 = 0x6809c0;
+    const COMMAND_COUNT_OFFSET: u32 = 0x680dc0;
+    let base = unsafe { GetModuleHandleA(null()) } as u32;
+
+    let command_list_size_ptr: *mut c_int = unsafe { transmute(base + COMMAND_LIST_SIZE_OFFSET) };
+    let command_list_ptr: *mut *const Command = unsafe { transmute(base + COMMAND_LIST_OFFSET) };
+    let command_count_ptr: *mut c_int = unsafe { transmute(base + COMMAND_COUNT_OFFSET) };
+    (command_list_size_ptr, command_list_ptr, command_count_ptr)
+}
+
 pub fn register_command_set(cmds: &[Command]) {
     let count = cmds.len() as i32;
     if count <= 0 {
@@ -83,50 +95,25 @@ pub fn register_command_set(cmds: &[Command]) {
     }
 
     let cmds_ptr = Box::leak(Box::new(cmds.to_vec())).as_ptr();
-
-    const COMMAND_LIST_SIZE_OFFSET: u32 = 0x6809bc;
-    const COMMAND_LIST_OFFSET: u32 = 0x6809c0;
-    const COMMAND_COUNT_OFFSET: u32 = 0x680dc0;
-    let base = unsafe { GetModuleHandleA(null()) } as u32;
-
-    let command_list_size_ptr: *mut c_int = unsafe { transmute(base + COMMAND_LIST_SIZE_OFFSET) };
-    let command_list_ptr: *mut *const Command = unsafe { transmute(base + COMMAND_LIST_OFFSET) };
-    let command_count_ptr: *mut c_int = unsafe { transmute(base + COMMAND_COUNT_OFFSET) };
-
+    let (command_list_size_ptr, command_list_ptr, command_count_ptr) = get_command_ptrs();
     unsafe {
-        println!("Command list size: {}", *command_list_size_ptr);
         let size_offset = (*command_list_size_ptr) as isize;
-        let set_ptr = command_list_ptr.offset(size_offset);
-        *set_ptr = cmds_ptr;
-        let count_ptr = command_count_ptr.offset(size_offset);
-        *count_ptr = count;
-        *command_list_size_ptr = *command_list_size_ptr + 1;
-        println!("Command list size: {}", *command_list_size_ptr);
-
-        let cmd = *cmds_ptr;
-        println!("Registered Cmd: {:?}", cmd);
+        *command_list_ptr.offset(size_offset) = cmds_ptr;
+        *command_count_ptr.offset(size_offset) = count;
+        *command_list_size_ptr += 1;
     };
 }
 
 pub extern "C" fn log_cmds() {
     let debug = &services().debug;
-
-    const COMMAND_LIST_SIZE_OFFSET: u32 = 0x6809bc;
-    const COMMAND_LIST_OFFSET: u32 = 0x6809c0;
-    const COMMAND_COUNT_OFFSET: u32 = 0x680dc0;
-    let base = unsafe { GetModuleHandleA(null()) } as u32;
-
-    let command_list_size_ptr: *mut c_int = unsafe { transmute(base + COMMAND_LIST_SIZE_OFFSET) };
-    let command_list_ptr: *mut *const Command = unsafe { transmute(base + COMMAND_LIST_OFFSET) };
-    let command_count_ptr: *mut c_int = unsafe { transmute(base + COMMAND_COUNT_OFFSET) };
-
+    let (command_list_size_ptr, command_list_ptr, command_count_ptr) = get_command_ptrs();
     unsafe {
-        for i in 0..(*command_list_size_ptr) {
-            let count = *(command_count_ptr.offset(i as isize));
+        for i in 0..*command_list_size_ptr {
+            let count = *command_count_ptr.offset(i as isize);
             debug.print(&format!("Command set contains {count} commands"));
             for j in 0..count {
                 let set_ptr = command_list_ptr.offset(i as isize);
-                let cmd = *((*set_ptr).offset(j as isize));
+                let cmd = *(*set_ptr).offset(j as isize);
                 debug.print(&format!("Command: {cmd}"));
             }
         }

--- a/examples/custom_commands/src/lib.rs
+++ b/examples/custom_commands/src/lib.rs
@@ -1,152 +1,15 @@
 use std::{
-    ffi::{CStr, CString, c_char, c_int, c_ulong, c_void},
-    fmt::Display,
-    ptr::null,
+    ffi::{c_char, c_void},
     result::Result,
-    sync::{LazyLock, Mutex},
 };
 
 use kc_osm::*;
-use windows_sys::Win32::System::LibraryLoader::GetModuleHandleA;
-
-#[derive(Debug, Default)]
-struct State {
-    commands: Vec<usize>,
-}
-
-fn cstr_convert(val: *const c_char) -> String {
-    if val.is_null() {
-        return "".to_owned();
-    }
-    unsafe { CStr::from_ptr(val).to_string_lossy().into_owned() }
-}
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub enum CommandType {
-    FuncVoid,
-    FuncBool,
-    FuncInt,
-    FuncFloat,
-    FuncDouble,
-    FuncString,
-    VarBool,
-    VarInt,
-    VarString,
-    VarIntArray,
-    VarFloat,
-    ToggleBool,
-    ToggleInt,
-}
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct Command {
-    pub name: *const c_char,
-    pub type_: CommandType,
-    pub val: *const c_void,
-    pub comment: *const c_char,
-    pub contexts: c_ulong,
-    unknown: c_int,
-}
-
-impl Command {
-    pub fn new(
-        name: &str,
-        help: &str,
-        type_: CommandType,
-        contexts: u32,
-        func: *const c_void,
-    ) -> Self {
-        Self {
-            name: CString::new(name).unwrap().into_raw(),
-            type_,
-            val: func,
-            comment: CString::new(help).unwrap().into_raw(),
-            contexts,
-            unknown: 0,
-        }
-    }
-}
-
-impl Display for Command {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let name = cstr_convert(self.name);
-        let comment = cstr_convert(self.comment);
-        write!(
-            f,
-            "('{}', {:?}, fn_ptr: {:?}, '{}', {}, {})",
-            name, self.type_, self.val, comment, self.contexts, self.unknown
-        )
-    }
-}
-
-pub fn get_command_ptrs() -> (*mut c_int, *mut *const Command, *mut c_int) {
-    let base = unsafe { GetModuleHandleA(null()) } as u32;
-    let command_list_size_ptr = (base + 0x6809bc) as *mut c_int;
-    let command_list_ptr = (base + 0x6809c0) as *mut *const Command;
-    let command_count_ptr = (base + 0x680dc0) as *mut c_int;
-    (command_list_size_ptr, command_list_ptr, command_count_ptr)
-}
-
-pub fn register_command_set(cmds: &[Command]) {
-    let count = cmds.len() as i32;
-    if count <= 0 {
-        return;
-    }
-
-    let cmds_ptr = Box::leak(Box::new(cmds.to_vec())).as_ptr();
-    let (command_list_size_ptr, command_list_ptr, command_count_ptr) = get_command_ptrs();
-    unsafe {
-        let size_offset = (*command_list_size_ptr) as isize;
-        *command_list_ptr.offset(size_offset) = cmds_ptr;
-        *command_count_ptr.offset(size_offset) = count;
-        *command_list_size_ptr += 1;
-    };
-
-    let mut state = get_state();
-    state.commands.push(cmds_ptr as usize);
-}
-
-pub fn deregister_command_sets() {
-    let state = get_state();
-    let (command_list_size_ptr, command_list_ptr, command_count_ptr) = get_command_ptrs();
-    unsafe {
-        for cmd_set in &state.commands {
-            let cmd_set_ptr = *cmd_set as *const Command;
-            let mut found = false;
-            for i in 0..*command_list_size_ptr {
-                if *command_list_ptr.offset(i as isize) == cmd_set_ptr {
-                    found = true;
-                }
-
-                if !found {
-                    continue;
-                }
-
-                // Shift everything afterwards down
-                *command_list_ptr.offset(i as isize) = *command_list_ptr.offset((i + 1) as isize);
-                *command_count_ptr.offset(i as isize) = *command_count_ptr.offset((i + 1) as isize);
-                *command_list_size_ptr -= 1;
-            }
-        }
-    };
-}
 
 pub extern "C" fn log_cmds() {
     let debug = &services().debug;
-    let (command_list_size_ptr, command_list_ptr, command_count_ptr) = get_command_ptrs();
-    unsafe {
-        for i in 0..*command_list_size_ptr {
-            let count = *command_count_ptr.offset(i as isize);
-            debug.print(&format!("Command set contains {count} commands"));
-            for j in 0..count {
-                let set_ptr = command_list_ptr.offset(i as isize);
-                let cmd = *(*set_ptr).offset(j as isize);
-                debug.print(&format!("Command: {cmd}"));
-            }
-        }
-    };
+    for cmd in get_all_command_infos() {
+        debug.print(&format!("Command: {cmd}"));
+    }
 }
 
 pub extern "C" fn print_shit() {
@@ -160,8 +23,8 @@ pub extern "C" fn echo(val: *const c_char) {
 }
 
 #[unsafe(no_mangle)]
-pub extern "Rust" fn module_init(_: &mut ScriptModule) -> Result<(), &'static str> {
-    register_command_set(&[
+pub extern "Rust" fn module_init(module: &mut ScriptModule) -> Result<(), &'static str> {
+    module.register_commands(&[
         Command::new(
             "jay_custom_command",
             "This is a custom command that does *something* epic",
@@ -186,21 +49,4 @@ pub extern "Rust" fn module_init(_: &mut ScriptModule) -> Result<(), &'static st
     ]);
 
     Ok(())
-}
-
-static STATE: LazyLock<Mutex<State>> = LazyLock::new(|| Mutex::new(State { commands: vec![] }));
-
-fn get_state<'a>() -> std::sync::MutexGuard<'a, State> {
-    STATE.lock().unwrap()
-}
-
-#[unsafe(no_mangle)]
-#[allow(non_snake_case, unused_variables)]
-extern "system" fn DllMain(dll_module: u32, call_reason: u32, _: *mut ()) -> bool {
-    match call_reason {
-        0 => deregister_command_sets(),
-        _ => (),
-    }
-
-    true
 }

--- a/examples/custom_commands/src/lib.rs
+++ b/examples/custom_commands/src/lib.rs
@@ -24,14 +24,14 @@ pub extern "Rust" fn module_init(module: &mut ScriptModule) -> Result<(), &'stat
             "log_cmds",
             "Output more detailed information for every command in dromed",
             CommandType::FuncVoid,
-            0xffffffff,
+            CommandContext::EDITOR,
             log_cmds as *const c_void,
         ),
         Command::new(
             "jecho",
             "Prints whatever the input string was to mono",
             CommandType::FuncString,
-            0xffffffff,
+            CommandContext::ALL,
             echo as *const c_void,
         ),
     ]);

--- a/examples/custom_commands/src/lib.rs
+++ b/examples/custom_commands/src/lib.rs
@@ -27,6 +27,19 @@ pub struct Command {
     unknown: c_int,
 }
 
+impl Command {
+    pub fn new(name: &str, help: &str, type_: i32, contexts: u32, func: *const c_void) -> Self {
+        Self {
+            name: CString::new(name).unwrap().into_raw(),
+            type_,
+            val: func,
+            comment: CString::new(help).unwrap().into_raw(),
+            contexts,
+            unknown: 0,
+        }
+    }
+}
+
 impl Display for Command {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let name = cstr_convert(self.name);
@@ -36,23 +49,6 @@ impl Display for Command {
             "('{}', {}, fn_ptr: {:?}, '{}', {}, {})",
             name, self.type_, self.val, comment, self.contexts, self.unknown
         )
-    }
-}
-
-pub fn build_command(
-    name: &str,
-    help: &str,
-    type_: i32,
-    contexts: u32,
-    val: *const c_void,
-) -> Command {
-    Command {
-        name: CString::new(name).unwrap().into_raw(),
-        type_,
-        val,
-        comment: CString::new(help).unwrap().into_raw(),
-        contexts,
-        unknown: 0,
     }
 }
 
@@ -126,21 +122,21 @@ pub extern "C" fn echo(val: *const c_char) {
 #[unsafe(no_mangle)]
 pub extern "Rust" fn module_init(_: &mut ScriptModule) -> Result<(), &'static str> {
     register_command_set(&[
-        build_command(
+        Command::new(
             "jay_custom_command",
             "This is a custom command that does *something* epic",
             0,
             0xffffffff,
             print_shit as *const c_void,
         ),
-        build_command(
+        Command::new(
             "log_cmds",
             "Output more detailed information for every command in dromed",
             0,
             0xffffffff,
             log_cmds as *const c_void,
         ),
-        build_command(
+        Command::new(
             "jecho",
             "Prints whatever the input string was to mono",
             5,


### PR DESCRIPTION
Adds the ability to register custom commands that can be ran in editor/game along with an example. Commands are neatly deregistered smoothly whenever the OSM is unloaded (manual drop, loading a new mission, reloading scripts).

Currently just supports DromEd 1.19 through to the latest 1.28. SS2 and game exe's are lower priority so they can be included later when they're needed. Only latest 1.28 is supported as I'm just version checking via the Version service which doesn't provide any differentiation between the 2 1.28 releases. If this ends up being problematic in the future it could be swapped to a memory signature approach.

Note that this includes a breaking change with the error type of `module_init` changing from `&'static str` to `String`. (Should have been to begin with really)