### PR TITLE
feat!: add message system and service macros from Peter's fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "dark-service-types"
+version = "0.0.1"
+
+[[package]]
 name = "dialog"
 version = "0.1.0"
 dependencies = [
@@ -53,6 +57,7 @@ dependencies = [
 name = "kc-osm-proc-macros"
 version = "0.0.1"
 dependencies = [
+ "dark-service-types",
  "heck",
  "proc-macro2",
  "quote",

--- a/crates/dark-service-types/Cargo.toml
+++ b/crates/dark-service-types/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "dark-service-types"
+version = "0.0.1"
+edition = "2024"
+authors = ["Jarrod Doyle <thejarroddoyle@gmail.com>", "Peter Wright <code@peter.works>"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/JarrodDoyle/osm-rs"

--- a/crates/dark-service-types/src/lib.rs
+++ b/crates/dark-service-types/src/lib.rs
@@ -1,0 +1,160 @@
+/// Standard COM GUID layout (16 bytes).
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct Guid {
+    pub data1: u32,
+    pub data2: u16,
+    pub data3: u16,
+    pub data4: [u8; 8],
+}
+
+impl std::fmt::Display for Guid {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{:08X}-{:04X}-{:04X}-{:02X}{:02X}-{:02X}{:02X}{:02X}{:02X}{:02X}{:02X}",
+            self.data1,
+            self.data2,
+            self.data3,
+            self.data4[0],
+            self.data4[1],
+            self.data4[2],
+            self.data4[3],
+            self.data4[4],
+            self.data4[5],
+            self.data4[6],
+            self.data4[7],
+        )
+    }
+}
+
+/// The fixed `data4` suffix shared by all LG GUIDs.
+const LG_GUID_DATA4: [u8; 8] = [0x83, 0x48, 0x00, 0xAA, 0x00, 0xA8, 0x2B, 0x51];
+
+/// Build a Dark Engine LG-style GUID from a service/interface ID.
+///
+/// Matches the `DEFINE_LG_GUID(name, id)` macro from the LGS SDK:
+/// ```text
+/// {((id&0xFF)<<24)|((id&0xFF00)<<16)|(id&0xFFFF),
+///  0x7A80+id, 0x11CF+id, {0x83,0x48,0x00,0xAA,0x00,0xA8,0x2B,0x51}}
+/// ```
+pub const fn lg_guid(id: u32) -> Guid {
+    Guid {
+        data1: ((id & 0xFF) << 24) | ((id & 0xFF00) << 16) | (id & 0xFFFF),
+        data2: (0x7A80 + id) as u16,
+        data3: (0x11CF + id) as u16,
+        data4: LG_GUID_DATA4,
+    }
+}
+
+/// Extract the LG service ID from a binary GUID, if it matches the LG pattern.
+///
+/// Returns `None` if `data4` doesn't match the LG suffix, or if `data2` and
+/// `data3` are inconsistent (i.e. don't encode the same ID).
+pub const fn lg_id_from_guid(guid: &Guid) -> Option<u16> {
+    // Check data4 matches the LG pattern
+    let d = &guid.data4;
+    if d[0] != 0x83
+        || d[1] != 0x48
+        || d[2] != 0x00
+        || d[3] != 0xAA
+        || d[4] != 0x00
+        || d[5] != 0xA8
+        || d[6] != 0x2B
+        || d[7] != 0x51
+    {
+        return None;
+    }
+    // Extract ID from data2 and cross-check with data3
+    let id_from_d2 = guid.data2.wrapping_sub(0x7A80);
+    let id_from_d3 = guid.data3.wrapping_sub(0x11CF);
+    if id_from_d2 != id_from_d3 {
+        return None;
+    }
+    Some(id_from_d2)
+}
+
+/// All script services exposed by the Dark Engine's IScriptMan::GetService.
+macro_rules! script_services {
+    ($($name:ident = $id:expr),* $(,)?) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        #[repr(u16)]
+        pub enum ScriptService {
+            $($name = $id),*
+        }
+
+        impl ScriptService {
+            pub const ALL: &[ScriptService] = &[$(Self::$name),*];
+
+            pub fn from_name(name: &str) -> Option<Self> {
+                match name {
+                    $(stringify!($name) => Some(Self::$name),)*
+                    _ => None,
+                }
+            }
+        }
+    }
+}
+
+script_services! {
+    Null          = 0x0F2,
+    Sound         = 0x0F1,
+    ActReact      = 0x0F4,
+    Locked        = 0x0FB,
+    Puppet        = 0x0FD,
+    Damage        = 0x0FE,
+    Door          = 0x0F6,
+    AI            = 0x0E5,
+    Debug         = 0x0D7,
+    Object        = 0x0DF,
+    Property      = 0x0DA,
+    Link          = 0x0EE,
+    LinkTools     = 0x0EF,
+    Key           = 0x10D,
+    Weapon        = 0x10E,
+    PickLock      = 0x111,
+    Bow           = 0x115,
+    Camera        = 0x140,
+    Physics       = 0x141,
+    DrkInv        = 0x150,
+    Inventory     = 0x15E,
+    Quest         = 0x152,
+    DrkPowerups   = 0x153,
+    PlayerLimbs   = 0x15D,
+    AnimTexture   = 0x16A,
+    Light         = 0x16C,
+    Container     = 0x17D,
+    DarkUI        = 0x19F,
+    Data          = 0x1A0,
+    DarkGame      = 0x1B4,
+    ShockPsi      = 0x1D7,
+    ShockObj      = 0x1D9,
+    PGroup        = 0x1F8,
+    ShockGame     = 0x108,
+    ShockWeapon   = 0x213,
+    ShockAI       = 0x21B,
+    Networking    = 0x225,
+    CD            = 0x226,
+    Version       = 0x228,
+    Engine        = 0x229,
+    ShockOverlay  = 0x22A,
+    DarkOverlay   = 0x22B,
+}
+
+impl ScriptService {
+    /// Returns the short service ID (e.g. `0x17D` for Container).
+    pub const fn id(self) -> u16 {
+        self as u16
+    }
+
+    /// Returns the LG GUID for this service.
+    pub const fn guid(self) -> Guid {
+        lg_guid(self as u32)
+    }
+
+    /// Returns the GUID as a hyphenated uppercase string,
+    /// e.g. `"7D00017D-7BFD-134C-8348-00AA00A82B51"`.
+    pub fn guid_string(self) -> String {
+        self.guid().to_string()
+    }
+}

--- a/crates/kc-osm-proc-macros/Cargo.toml
+++ b/crates/kc-osm-proc-macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kc-osm-proc-macros"
 version = "0.0.1"
 edition = "2024"
-authors = ["Jarrod Doyle <thejarroddoyle@gmail.com>"]
+authors = ["Jarrod Doyle <thejarroddoyle@gmail.com>", "Peter Wright <code@peter.works>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/JarrodDoyle/osm-rs"
 description = "The dark_script macro for the kc-osm crate"
@@ -15,3 +15,4 @@ heck = "0.5.0"
 proc-macro2 = "1.0.101"
 quote = "1.0.41"
 syn = { version = "2.0.107", features = ["full"] }
+dark-service-types = { version = "0.0.1", path = "../dark-service-types" }

--- a/crates/kc-osm-proc-macros/src/lib.rs
+++ b/crates/kc-osm-proc-macros/src/lib.rs
@@ -8,10 +8,7 @@ use quote::{ToTokens, format_ident, quote};
 use syn::Data;
 use syn::DeriveInput;
 use syn::spanned::Spanned;
-use syn::{
-    Field, Fields, Ident, ItemStruct, Meta, parse::Parser, parse_macro_input,
-    punctuated::Punctuated,
-};
+use syn::{Ident, ItemStruct, Meta, parse_macro_input, punctuated::Punctuated};
 
 /// Defines a Dark Engine scripting service COM interface.
 ///
@@ -49,37 +46,96 @@ pub fn dark_service(attr: TokenStream, item: TokenStream) -> TokenStream {
     .into()
 }
 
+/// Returns the message type identifier for a given Dark Engine message name.
+fn msg_type_for(message: &str) -> Ident {
+    if message.ends_with("Stimulus") {
+        return Ident::new("sStimMsg", Span::call_site());
+    }
+
+    match message {
+        "Timer" => Ident::new("sScrTimerMsg", Span::call_site()),
+        "TweqComplete" => Ident::new("sTweqMsg", Span::call_site()),
+        "SoundDone" => Ident::new("sSoundDoneMsg", Span::call_site()),
+        "SchemaDone" => Ident::new("sSchemaDoneMsg", Span::call_site()),
+        "Sim" => Ident::new("sSimMsg", Span::call_site()),
+        "ObjRoomTransit"
+        | "PlayerRoomEnter"
+        | "PlayerRoomExit"
+        | "RemotePlayerRoomEnter"
+        | "RemotePlayerRoomExit"
+        | "CreatureRoomEnter"
+        | "CreatureRoomExit"
+        | "ObjectRoomEnter"
+        | "ObjectRoomExit" => Ident::new("sRoomMsg", Span::call_site()),
+        "QuestChange" => Ident::new("sQuestMsg", Span::call_site()),
+        "MovingTerrainWaypoint" => Ident::new("sMovingTerrainMsg", Span::call_site()),
+        "WaypointReached" => Ident::new("sWaypointMsg", Span::call_site()),
+        "MediumTransition" => Ident::new("sMediumTransMsg", Span::call_site()),
+        "FrobToolBegin" | "FrobToolEnd" | "FrobWorldBegin" | "FrobWorldEnd" | "FrobInvBegin"
+        | "FrobInvEnd" => Ident::new("sFrobMsg", Span::call_site()),
+        "DoorOpen" | "DoorClose" | "DoorOpening" | "DoorClosing" | "DoorHalt" => {
+            Ident::new("sDoorMsg", Span::call_site())
+        }
+        "Difficulty" => Ident::new("sDiffScrMsg", Span::call_site()),
+        "Damage" => Ident::new("sDamageScrMsg", Span::call_site()),
+        "Slain" => Ident::new("sSlayMsg", Span::call_site()),
+        "Container" => Ident::new("sContainerScrMsg", Span::call_site()),
+        "Contained" => Ident::new("sContainedScrMsg", Span::call_site()),
+        "Combine" => Ident::new("sCombineScrMsg", Span::call_site()),
+        "ContainSimActivate" | "ContainAdd" | "ContainRemove" | "ContainCombine" => {
+            Ident::new("sContainMsg", Span::call_site())
+        }
+        "MotionStart" | "MotionEnd" | "MotionFlagReached" => {
+            Ident::new("sBodyMsg", Span::call_site())
+        }
+        "StartWindup" | "StartAttack" | "EndAttack" => Ident::new("sAttackMsg", Span::call_site()),
+        "SignalAI" => Ident::new("sAISignalMsg", Span::call_site()),
+        "PatrolPoint" => Ident::new("sAIPatrolPointMsg", Span::call_site()),
+        "Alertness" | "HighAlert" => Ident::new("sAIAlertnessMsg", Span::call_site()),
+        "AIModeChange" => Ident::new("sAIModeChangeMsg", Span::call_site()),
+        "ObjActResult" => Ident::new("sAIObjActResultMsg", Span::call_site()),
+        "PhysFellAsleep"
+        | "PhysWokeUp"
+        | "PhysMadePhysical"
+        | "PhysMadeNonPhysical"
+        | "PhysCollision"
+        | "PhysContactCreate"
+        | "PhysContactDestroy"
+        | "PhysEnter"
+        | "PhysExit" => Ident::new("sPhysMsg", Span::call_site()),
+        "ReportMessage" => Ident::new("sReportMsg", Span::call_site()),
+        "PropNotify" => Ident::new("sPropNotifyMsg", Span::call_site()),
+        "ObjNotify" => Ident::new("sObjNotifyMsg", Span::call_site()),
+        "LinkNotify" => Ident::new("sLinkNotifyMsg", Span::call_site()),
+        "TraitNotify" => Ident::new("sTraitNotifyMsg", Span::call_site()),
+        "DarkGameModeChange" => Ident::new("sDarkGameModeScrMsg", Span::call_site()),
+        "PickStateChange" => Ident::new("sPickStateScrMsg", Span::call_site()),
+        "YorNDone" => Ident::new("sYorNMsg", Span::call_site()),
+        "KeypadDone" => Ident::new("sKeypadMsg", Span::call_site()),
+        _ => Ident::new("sScrMsg", Span::call_site()),
+    }
+}
+
 #[proc_macro_attribute]
 pub fn dark_script(attr: TokenStream, item: TokenStream) -> TokenStream {
     let messages =
         parse_macro_input!(attr with Punctuated::<Meta, syn::Token![,]>::parse_terminated);
 
-    let mut registrations = TokenStream2::default();
-    for msg in messages {
+    let mut match_arms = TokenStream2::default();
+    for msg in &messages {
         let message = msg.to_token_stream().to_string();
         let message_func = Ident::new(
             &format!("on_{}", message.to_snake_case()),
             Span::call_site(),
         );
-        registrations.extend(quote! {
-            self.handlers.insert(#message.to_string(), Self::#message_func);
+
+        let msg_type = msg_type_for(&message);
+        match_arms.extend(quote! {
+            #message => self.#message_func(services, #msg_type::from_base_msg(msg)),
         });
     }
 
-    let mut item = parse_macro_input!(item as ItemStruct);
-
-    if let Fields::Named(ref mut fields) = item.fields {
-        fields.named.push(
-            Field::parse_named
-                .parse2(
-                    quote! {
-                        handlers: std::collections::HashMap<String, fn(&Self, &Services, &sScrMsg) -> HRESULT>
-                    },
-                )
-                .unwrap(),
-        );
-    }
-
+    let item = parse_macro_input!(item as ItemStruct);
     let name = &item.ident;
     let script_name = name.to_string();
     let script_impl_block = format_ident!("{}_Impl", &name);
@@ -89,12 +145,6 @@ pub fn dark_script(attr: TokenStream, item: TokenStream) -> TokenStream {
         #[derive(Default, Debug)]
         #item
 
-        impl #name {
-            fn register_handlers(&mut self) {
-                #registrations
-            }
-        }
-
         impl IScript_Impl for #script_impl_block {
             unsafe fn GetClassName(&self) -> *const std::ffi::c_char {
                 std::ffi::CString::from_str(#script_name).unwrap().into_raw()
@@ -102,15 +152,14 @@ pub fn dark_script(attr: TokenStream, item: TokenStream) -> TokenStream {
 
             unsafe fn ReceiveMessage(&self, msg: &mut sScrMsg, _: &mut sMultiParm, _: i32) -> HRESULT {
                 let services = services();
-
                 let message_name = unsafe {
                     std::ffi::CStr::from_ptr(msg.message).to_str().unwrap()
                 };
-                if self.handlers.contains_key(message_name) {
-                    return self.handlers[message_name](self, services, msg);
-                }
 
-                HRESULT(1)
+                match message_name {
+                    #match_arms
+                    _ => HRESULT(1),
+                }
             }
         }
 
@@ -131,15 +180,32 @@ pub fn dark_script(attr: TokenStream, item: TokenStream) -> TokenStream {
                 _id: std::ffi::c_int
             ) -> *mut IScript {
                 let mut ret: *mut std::ffi::c_void = std::ptr::null_mut();
-                let mut script = Self::default();
-                script.register_handlers();
-                let script_interface: IScript = script.into();
+                let script: IScript = Self::default().into();
                 let guid = IScript::IID;
-                let query_result = unsafe { script_interface.query(&raw const guid, &mut ret) };
+                let query_result = unsafe { script.query(&raw const guid, &mut ret) };
                 if !HRESULT::is_ok(query_result) {
                     return std::ptr::null_mut();
                 }
                 ret as *mut IScript
+            }
+        }
+    }
+    .into()
+}
+
+#[proc_macro_derive(DarkMessageData)]
+pub fn dark_message_data(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let ident = &input.ident;
+
+    quote! {
+        impl DarkMessageData for #ident {
+            /// Cast a base [`sScrMsg`] to [`#ident`].
+            ///
+            /// # Safety
+            /// Caller must ensure the underlying data is actually of type [`#ident`].
+            unsafe fn from_base_msg(msg: &sScrMsg) -> &Self {
+                unsafe { &*(msg as *const sScrMsg as *const Self) }
             }
         }
     }

--- a/crates/kc-osm-proc-macros/src/lib.rs
+++ b/crates/kc-osm-proc-macros/src/lib.rs
@@ -131,7 +131,7 @@ pub fn dark_script(attr: TokenStream, item: TokenStream) -> TokenStream {
 
         let msg_type = msg_type_for(&message);
         match_arms.extend(quote! {
-            #message => self.#message_func(services, #msg_type::from_base_msg(msg)),
+            #message => self.#message_func(services, #msg_type::from_base_msg(msg), reply),
         });
     }
 
@@ -150,7 +150,7 @@ pub fn dark_script(attr: TokenStream, item: TokenStream) -> TokenStream {
                 std::ffi::CString::from_str(#script_name).unwrap().into_raw()
             }
 
-            unsafe fn ReceiveMessage(&self, msg: &mut sScrMsg, _: &mut sMultiParm, _: i32) -> HRESULT {
+            unsafe fn ReceiveMessage(&self, msg: &mut sScrMsg, reply: &mut sMultiParm, _: i32) -> HRESULT {
                 let services = services();
                 let message_name = unsafe {
                     std::ffi::CStr::from_ptr(msg.message).to_str().unwrap()

--- a/crates/kc-osm-proc-macros/src/lib.rs
+++ b/crates/kc-osm-proc-macros/src/lib.rs
@@ -1,3 +1,4 @@
+use dark_service_types::ScriptService;
 use heck::ToSnakeCase;
 use proc_macro::TokenStream;
 use proc_macro2::Span;
@@ -11,6 +12,42 @@ use syn::{
     Field, Fields, Ident, ItemStruct, Meta, parse::Parser, parse_macro_input,
     punctuated::Punctuated,
 };
+
+/// Defines a Dark Engine scripting service COM interface.
+///
+/// Takes a [`ScriptService`] variant name and computes the COM GUID, then
+/// delegates to [`windows_core::interface`].
+///
+/// # Example
+/// ```ignore
+/// #[dark_service(Container)]
+/// unsafe trait IContainerService: IUnknown { ... }
+/// ```
+///
+/// Expands to:
+/// ```ignore
+/// #[windows_core::interface("7D00017D-7BFD-134C-8348-00AA00A82B51")]
+/// unsafe trait IContainerService: IUnknown { ... }
+/// ```
+#[proc_macro_attribute]
+pub fn dark_service(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let ident = parse_macro_input!(attr as Ident);
+    let guid = match ScriptService::from_name(&ident.to_string()) {
+        Some(svc) => svc.guid_string(),
+        None => {
+            return syn::Error::new_spanned(&ident, format!("Unknown `ScriptService`: `{ident}`"))
+                .to_compile_error()
+                .into();
+        }
+    };
+
+    let item: TokenStream2 = item.into();
+    quote! {
+        #[windows_core::interface(#guid)]
+        #item
+    }
+    .into()
+}
 
 #[proc_macro_attribute]
 pub fn dark_script(attr: TokenStream, item: TokenStream) -> TokenStream {

--- a/crates/kc-osm/Cargo.toml
+++ b/crates/kc-osm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kc-osm"
 version = "0.0.1"
 edition = "2024"
-authors = ["Jarrod Doyle <thejarroddoyle@gmail.com>"]
+authors = ["Jarrod Doyle <thejarroddoyle@gmail.com>", "Peter Wright <code@peter.works>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/JarrodDoyle/osm-rs"
 description = "Helper library for writing Dark Engine object script modules (OSMs)"

--- a/crates/kc-osm/src/commands.rs
+++ b/crates/kc-osm/src/commands.rs
@@ -102,7 +102,10 @@ impl Command {
 }
 
 fn get_command_ptrs() -> Option<(*mut c_int, *mut *const Command, *mut c_int)> {
-    let version = &services().version;
+    let Some(version) = &services().version else {
+        return None;
+    };
+
     let offsets = match (version.get_version(), version.is_editor() != 0) {
         ((1, 19), true) => (0x5f86fc, 0x5f8700, 0x5f8b00),
         ((1, 20), true) => (0x6023bc, 0x6023c0, 0x6027c0),

--- a/crates/kc-osm/src/lib.rs
+++ b/crates/kc-osm/src/lib.rs
@@ -328,7 +328,9 @@ extern "stdcall" fn ScriptModuleInit(
         match module_init(&mut test_mod) {
             Ok(_) => test_mod.register(out_mod).into(),
             Err(e) => {
-                services().debug.print(&e);
+                if let Some(debug) = &services().debug {
+                    debug.print(&e);
+                }
                 false.into()
             }
         }

--- a/crates/kc-osm/src/lib.rs
+++ b/crates/kc-osm/src/lib.rs
@@ -1,6 +1,7 @@
 mod commands;
 pub mod dialogs;
 mod malloc;
+pub mod messages;
 mod services;
 
 use std::{
@@ -12,10 +13,48 @@ use std::{
 pub use crate::commands::{
     Command, CommandContext, CommandRegisterError, CommandType, get_all_command_infos,
 };
-use crate::commands::{deregister_command_sets, register_command_set};
 pub use crate::services::*;
+use crate::{
+    commands::{deregister_command_sets, register_command_set},
+    messages::sScrMsg,
+};
 pub use kc_osm_proc_macros::{EdittableStruct, dark_script};
 pub use windows::{Win32::System::Com::IMalloc, core::*};
+
+/// Dark Engine object identifier. Wraps a raw `i32` for type safety.
+///
+/// - Negative values are archetypes (e.g. Weapon = -30)
+/// - Positive values are concrete objects (e.g. a specific sword instance)
+/// - Zero means "no object" or "any" (wildcard in link queries)
+///
+/// Use `Option<ObjectId>` for APIs where zero means "not found".
+#[repr(transparent)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ObjectId(pub i32);
+
+impl ObjectId {
+    /// Returns `true` if this is an archetype (negative ID).
+    #[must_use]
+    pub fn is_archetype(self) -> bool {
+        self.0 < 0
+    }
+
+    /// Returns `true` if this is a concrete object (positive ID).
+    #[must_use]
+    pub fn is_concrete(self) -> bool {
+        self.0 > 0
+    }
+}
+
+impl std::fmt::Display for ObjectId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[repr(transparent)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct LinkId(pub i32);
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -89,22 +128,6 @@ pub struct sPersistentVtbl {
     pub Persistence: Option<unsafe extern "C" fn(arg1: *mut sPersistentVtbl) -> BOOL>,
     pub GetName:
         Option<unsafe extern "C" fn(arg1: *mut sPersistentVtbl) -> *const ::std::os::raw::c_char>,
-}
-
-#[repr(C)]
-#[derive(Copy, Clone, Debug)]
-pub struct sScrMsg {
-    pub lpVtbl: *mut IUnknown_Vtbl,
-    pub count: c_uint,
-    pub lpPersistentVtbl: *mut sPersistentVtbl,
-    pub from: c_int,
-    pub to: c_int,
-    pub message: *const c_char,
-    pub time: c_ulong,
-    pub flags: c_int,
-    pub data: sMultiParm,
-    pub data2: sMultiParm,
-    pub data3: sMultiParm,
 }
 
 #[interface("D00000D0-7B50-129F-8348-00AA00A82B51")]

--- a/crates/kc-osm/src/messages.rs
+++ b/crates/kc-osm/src/messages.rs
@@ -1,0 +1,1159 @@
+use std::ffi::{c_char, c_float, c_int, c_uint, c_ulong};
+
+use kc_osm_proc_macros::DarkMessageData;
+use windows::core::*;
+
+use crate::{LinkId, ObjectId, cstr_convert, sMultiParm, sPersistentVtbl, sVector};
+
+pub trait DarkMessageData {
+    unsafe fn from_base_msg(msg: &sScrMsg) -> &Self;
+}
+
+/// Base message data.
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct sScrMsg {
+    pub lpVtbl: *mut IUnknown_Vtbl,
+    pub count: c_uint,
+    pub lpPersistentVtbl: *mut sPersistentVtbl,
+    pub from: ObjectId,
+    pub to: ObjectId,
+    pub message: *const c_char,
+    pub time: c_ulong,
+    pub flags: c_int,
+    pub data: sMultiParm,
+    pub data2: sMultiParm,
+    pub data3: sMultiParm,
+}
+
+impl DarkMessageData for sScrMsg {
+    unsafe fn from_base_msg(msg: &sScrMsg) -> &Self {
+        msg
+    }
+}
+
+/// Timer message data.
+///
+/// Received for the following messages:
+///  - Timer
+#[repr(C)]
+#[derive(Copy, Clone, Debug, DarkMessageData)]
+pub struct sScrTimerMsg {
+    pub base: sScrMsg,
+    raw_name: *const c_char,
+}
+
+impl sScrTimerMsg {
+    #[must_use]
+    pub fn timer_name(&self) -> String {
+        cstr_convert(self.raw_name)
+    }
+}
+
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TweqType {
+    Scale,
+    Rotate,
+    Joints,
+    Models,
+    Delete,
+    Emitter,
+    Flicker,
+    Lock,
+    All,
+    Null,
+}
+
+impl TryFrom<i32> for TweqType {
+    type Error = i32;
+    fn try_from(v: i32) -> std::result::Result<Self, Self::Error> {
+        match v {
+            0 => Ok(Self::Scale),
+            1 => Ok(Self::Rotate),
+            2 => Ok(Self::Joints),
+            3 => Ok(Self::Models),
+            4 => Ok(Self::Delete),
+            5 => Ok(Self::Emitter),
+            6 => Ok(Self::Flicker),
+            7 => Ok(Self::Lock),
+            8 => Ok(Self::All),
+            9 => Ok(Self::Null),
+            _ => Err(v),
+        }
+    }
+}
+
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TweqOperation {
+    KillAll,
+    RemoveTweq,
+    HaltTweq,
+    StatusQuo,
+    SlayAll,
+    FrameEvent,
+}
+
+impl TryFrom<i32> for TweqOperation {
+    type Error = i32;
+
+    fn try_from(v: i32) -> std::result::Result<Self, Self::Error> {
+        match v {
+            0 => Ok(Self::KillAll),
+            1 => Ok(Self::RemoveTweq),
+            2 => Ok(Self::HaltTweq),
+            3 => Ok(Self::StatusQuo),
+            4 => Ok(Self::SlayAll),
+            5 => Ok(Self::FrameEvent),
+            _ => Err(v),
+        }
+    }
+}
+
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TweqDirection {
+    Forward,
+    Reverse,
+}
+
+impl TryFrom<i32> for TweqDirection {
+    type Error = i32;
+
+    fn try_from(v: i32) -> std::result::Result<Self, Self::Error> {
+        match v {
+            0 => Ok(Self::Forward),
+            1 => Ok(Self::Reverse),
+            _ => Err(v),
+        }
+    }
+}
+
+/// Tweq message data.
+///
+/// Received for the following messages:
+///  - TweqComplete
+#[repr(C)]
+#[derive(Copy, Clone, Debug, DarkMessageData)]
+pub struct sTweqMsg {
+    pub base: sScrMsg,
+    type_raw: c_int,
+    operation_raw: c_int,
+    direction_raw: c_int,
+}
+
+impl sTweqMsg {
+    pub fn tweq_type(&self) -> std::result::Result<TweqType, i32> {
+        TweqType::try_from(self.type_raw)
+    }
+
+    pub fn tweq_operation(&self) -> std::result::Result<TweqOperation, i32> {
+        TweqOperation::try_from(self.operation_raw)
+    }
+
+    pub fn tweq_direction(&self) -> std::result::Result<TweqDirection, i32> {
+        TweqDirection::try_from(self.direction_raw)
+    }
+}
+
+/// Sound done message data.
+///
+/// Received for the following messages:
+///  - SoundDone
+#[repr(C)]
+#[derive(Copy, Clone, Debug, DarkMessageData)]
+pub struct sSoundDoneMsg {
+    pub base: sScrMsg,
+    pub coordinates: sVector,
+    pub target_object: ObjectId,
+    name_raw: *const c_char,
+}
+
+impl sSoundDoneMsg {
+    pub fn name(&self) -> String {
+        cstr_convert(self.name_raw)
+    }
+}
+
+/// Schema done message data.
+///
+/// Received for the following messages:
+///  - SchemaDone
+#[repr(C)]
+#[derive(Copy, Clone, Debug, DarkMessageData)]
+pub struct sSchemaDoneMsg {
+    pub base: sScrMsg,
+    pub coordinates: sVector,
+    pub target_object: ObjectId,
+    name_raw: *const c_char,
+}
+
+impl sSchemaDoneMsg {
+    pub fn name(&self) -> String {
+        cstr_convert(self.name_raw)
+    }
+}
+
+/// Sim message data.
+///
+/// Received for the following messages:
+///  - Sim
+#[repr(C)]
+#[derive(Copy, Clone, Debug, DarkMessageData)]
+pub struct sSimMsg {
+    pub base: sScrMsg,
+    starting_raw: c_int,
+}
+
+impl sSimMsg {
+    pub fn starting(&self) -> bool {
+        self.starting_raw > 0
+    }
+}
+
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ObjType {
+    Player,
+    RemotePlayer,
+    Creature,
+    Object,
+    Null,
+}
+
+impl TryFrom<i32> for ObjType {
+    type Error = i32;
+    fn try_from(v: i32) -> std::result::Result<Self, Self::Error> {
+        match v {
+            0 => Ok(Self::Player),
+            1 => Ok(Self::RemotePlayer),
+            2 => Ok(Self::Creature),
+            3 => Ok(Self::Object),
+            4 => Ok(Self::Null),
+            _ => Err(v),
+        }
+    }
+}
+
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RoomChange {
+    Enter,
+    Exit,
+    RoomTransit,
+}
+
+impl TryFrom<i32> for RoomChange {
+    type Error = i32;
+    fn try_from(v: i32) -> std::result::Result<Self, Self::Error> {
+        match v {
+            0 => Ok(Self::Enter),
+            1 => Ok(Self::Exit),
+            2 => Ok(Self::RoomTransit),
+            _ => Err(v),
+        }
+    }
+}
+
+/// Room transition message data.
+///
+/// Received for the following messages:
+///  - ObjRoomTransit
+///  - PlayerRoomEnter
+///  - PlayerRoomExit
+///  - RemotePlayerRoomEnter
+///  - RemotePlayerRoomExit
+///  - CreatureRoomEnter
+///  - CreatureRoomExit
+///  - ObjectRoomEnter
+///  - ObjectRoomExit
+#[repr(C)]
+#[derive(Copy, Clone, Debug, DarkMessageData)]
+pub struct sRoomMsg {
+    pub base: sScrMsg,
+    pub from_obj_id: ObjectId,
+    pub to_obj_id: ObjectId,
+    pub move_obj_id: ObjectId,
+    obj_type_raw: c_int,
+    transition_type_raw: c_int,
+}
+
+impl sRoomMsg {
+    pub fn obj_type(&self) -> std::result::Result<ObjType, i32> {
+        ObjType::try_from(self.obj_type_raw)
+    }
+
+    pub fn transition_type(&self) -> std::result::Result<RoomChange, i32> {
+        RoomChange::try_from(self.transition_type_raw)
+    }
+}
+
+/// Quest message data.
+///
+/// Received for the following messages:
+///  - QuestChange
+#[repr(C)]
+#[derive(Copy, Clone, Debug, DarkMessageData)]
+pub struct sQuestMsg {
+    pub base: sScrMsg,
+    name_raw: *const c_char,
+    pub old_value: c_int,
+    pub new_value: c_int,
+}
+
+impl sQuestMsg {
+    pub fn name(&self) -> String {
+        cstr_convert(self.name_raw)
+    }
+}
+
+/// Moving terrain message data.
+///
+/// Received for the following messages:
+///  - MovingTerrainWaypoint
+#[repr(C)]
+#[derive(Copy, Clone, Debug, DarkMessageData)]
+pub struct sMovingTerrainMsg {
+    pub base: sScrMsg,
+    pub waypoint_obj_id: ObjectId,
+}
+
+/// Waypoint terrain message data.
+///
+/// Received for the following messages:
+///  - WaypointReached
+#[repr(C)]
+#[derive(Copy, Clone, Debug, DarkMessageData)]
+pub struct sWaypointMsg {
+    pub base: sScrMsg,
+    pub moving_terrain_obj_id: ObjectId,
+}
+
+/// Medium transition message data.
+///
+/// Received for the following messages:
+///  - MediumTransition
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct sMediumTransMsg {
+    pub base: sScrMsg,
+    pub from_type: c_int,
+    pub to_type: c_int,
+}
+
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrobLocation {
+    World,
+    Inv,
+    Tool,
+    None,
+}
+
+impl TryFrom<i32> for FrobLocation {
+    type Error = i32;
+    fn try_from(v: i32) -> std::result::Result<Self, Self::Error> {
+        match v {
+            0 => Ok(Self::World),
+            1 => Ok(Self::Inv),
+            2 => Ok(Self::Tool),
+            3 => Ok(Self::None),
+            _ => Err(v),
+        }
+    }
+}
+
+/// Frob message data.
+///
+/// Received for the following messages:
+///  - FrobToolBegin
+///  - FrobToolEnd
+///  - FrobWorldBegin
+///  - FrobWorldEnd
+///  - FrobInvBegin
+///  - FrobInvEnd
+#[repr(C)]
+#[derive(Copy, Clone, Debug, DarkMessageData)]
+pub struct sFrobMsg {
+    pub base: sScrMsg,
+    pub src_obj_id: ObjectId,
+    pub dest_obj_id: ObjectId,
+    pub frobber_obj_id: ObjectId,
+    src_location_raw: c_int,
+    dest_location_raw: c_int,
+    pub sec: c_float,
+    abort_raw: c_int,
+}
+
+impl sFrobMsg {
+    pub fn source_location(&self) -> std::result::Result<FrobLocation, i32> {
+        FrobLocation::try_from(self.src_location_raw)
+    }
+
+    pub fn destination_location(&self) -> std::result::Result<FrobLocation, i32> {
+        FrobLocation::try_from(self.dest_location_raw)
+    }
+
+    pub fn abort(&self) -> bool {
+        self.abort_raw > 0
+    }
+}
+
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DoorAction {
+    Open = 0,
+    Close = 1,
+    Opening = 2,
+    Closing = 3,
+    Halt = 4,
+}
+
+impl TryFrom<i32> for DoorAction {
+    type Error = i32;
+    fn try_from(v: i32) -> std::result::Result<Self, i32> {
+        match v {
+            0 => Ok(Self::Open),
+            1 => Ok(Self::Close),
+            2 => Ok(Self::Opening),
+            3 => Ok(Self::Closing),
+            4 => Ok(Self::Halt),
+            _ => Err(v),
+        }
+    }
+}
+
+/// Door message data.
+///
+/// Received for the following messages:
+///  - DoorOpen
+///  - DoorClose
+///  - DoorOpening
+///  - DoorClosing
+///  - DoorHalt
+#[repr(C)]
+#[derive(Copy, Clone, Debug, DarkMessageData)]
+pub struct sDoorMsg {
+    pub base: sScrMsg,
+    action_raw: c_int,
+    prev_action_raw: c_int,
+    proxy_raw: c_int,
+}
+
+impl sDoorMsg {
+    pub fn action(&self) -> std::result::Result<DoorAction, i32> {
+        DoorAction::try_from(self.action_raw)
+    }
+
+    pub fn previous_action(&self) -> std::result::Result<DoorAction, i32> {
+        DoorAction::try_from(self.prev_action_raw)
+    }
+
+    pub fn is_proxy(&self) -> bool {
+        self.proxy_raw > 0
+    }
+}
+
+/// Difficulty message data.
+///
+/// Received for the following messages:
+///  - Difficulty
+#[repr(C)]
+#[derive(Copy, Clone, Debug, DarkMessageData)]
+pub struct sDiffScrMsg {
+    pub base: sScrMsg,
+    pub difficulty: c_int,
+}
+
+/// Damage message data.
+///
+/// Received for the following messages:
+///  - Damage
+#[repr(C)]
+#[derive(Copy, Clone, Debug, DarkMessageData)]
+pub struct sDamageScrMsg {
+    pub base: sScrMsg,
+    pub kind: c_int,
+    pub damage: c_int,
+    pub culprit_obj_id: ObjectId,
+}
+
+/// Slay message data.
+///
+/// Received for the following messages:
+///  - Slain
+#[repr(C)]
+#[derive(Copy, Clone, Debug, DarkMessageData)]
+pub struct sSlayMsg {
+    pub base: sScrMsg,
+    pub culprit_obj_id: ObjectId,
+    pub kind: c_int,
+}
+
+/// Container message data.
+///
+/// Received for the following messages:
+///  - Container
+#[repr(C)]
+#[derive(Copy, Clone, Debug, DarkMessageData)]
+pub struct sContainerScrMsg {
+    pub base: sScrMsg,
+    pub containee_obj_id: ObjectId,
+}
+
+/// Contained message data.
+///
+/// Received for the following messages:
+///  - Contained
+#[repr(C)]
+#[derive(Copy, Clone, Debug, DarkMessageData)]
+pub struct sContainedScrMsg {
+    pub base: sScrMsg,
+    pub container_obj_id: ObjectId,
+}
+
+/// Combine message data.
+///
+/// Received for the following messages:
+///  - Combine
+#[repr(C)]
+#[derive(Copy, Clone, Debug, DarkMessageData)]
+pub struct sCombineScrMsg {
+    pub base: sScrMsg,
+    pub combiner_obj_id: ObjectId,
+}
+
+/// Contain message data.
+///
+/// Received for the following messages:
+///  - ContainSimActivate
+///  - ContainAdd
+///  - ContainRemove
+///  - ContainCombine
+#[repr(C)]
+#[derive(Copy, Clone, Debug, DarkMessageData)]
+pub struct sContainMsg {
+    pub base: sScrMsg,
+    pub container_obj_id: ObjectId,
+    pub containee_obj_id: ObjectId,
+}
+
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BodyAction {
+    MotionStart = 0,
+    MotionEnd = 1,
+    MotionFlagReached = 2,
+}
+
+impl TryFrom<i32> for BodyAction {
+    type Error = i32;
+    fn try_from(v: i32) -> std::result::Result<Self, i32> {
+        match v {
+            0 => Ok(Self::MotionStart),
+            1 => Ok(Self::MotionEnd),
+            2 => Ok(Self::MotionFlagReached),
+            _ => Err(v),
+        }
+    }
+}
+
+/// Body message data.
+///
+/// Received for the following messages:
+///  - MotionStart
+///  - MotionEnd
+///  - MotionFlagReached
+#[repr(C)]
+#[derive(Copy, Clone, Debug, DarkMessageData)]
+pub struct sBodyMsg {
+    pub base: sScrMsg,
+    action_type_raw: c_int,
+    motion_name_raw: *const c_char,
+    pub flag_value: c_int,
+}
+
+impl sBodyMsg {
+    pub fn action(&self) -> std::result::Result<BodyAction, i32> {
+        BodyAction::try_from(self.action_type_raw)
+    }
+
+    pub fn motion_name(&self) -> String {
+        cstr_convert(self.motion_name_raw)
+    }
+}
+
+/// Attack message data.
+///
+/// Received for the following messages:
+///  - StartWindup
+///  - StartAttack
+///  - EndAttack
+#[repr(C)]
+#[derive(Copy, Clone, Debug, DarkMessageData)]
+pub struct sAttackMsg {
+    pub base: sScrMsg,
+    pub weapon_obj_id: ObjectId,
+}
+
+/// AI signal message data.
+///
+/// Received for the following messages:
+///  - SignalAI
+#[repr(C)]
+#[derive(Copy, Clone, Debug, DarkMessageData)]
+pub struct sAISignalMsg {
+    pub base: sScrMsg,
+    signal_raw: *const c_char,
+}
+
+impl sAISignalMsg {
+    pub fn signal(&self) -> String {
+        cstr_convert(self.signal_raw)
+    }
+}
+
+/// AI patrol message data.
+///
+/// Received for the following messages:
+///  - PatrolPoint
+#[repr(C)]
+#[derive(Copy, Clone, Debug, DarkMessageData)]
+pub struct sAIPatrolPointMsg {
+    pub base: sScrMsg,
+    pub patrol_obj_id: ObjectId,
+}
+
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AIScriptAlertLevel {
+    NoAlert,
+    LowAlert,
+    ModerateAlert,
+    HighAlert,
+}
+
+impl TryFrom<i32> for AIScriptAlertLevel {
+    type Error = i32;
+    fn try_from(v: i32) -> std::result::Result<Self, Self::Error> {
+        match v {
+            0 => Ok(Self::NoAlert),
+            1 => Ok(Self::LowAlert),
+            2 => Ok(Self::ModerateAlert),
+            3 => Ok(Self::HighAlert),
+            _ => Err(v),
+        }
+    }
+}
+
+/// AI alertness message data.
+///
+/// Received for the following messages:
+///  - Alertness
+///  - HighAlert
+#[repr(C)]
+#[derive(Copy, Clone, Debug, DarkMessageData)]
+pub struct sAIAlertnessMsg {
+    pub base: sScrMsg,
+    level_raw: c_int,
+    previous_level_raw: c_int,
+}
+
+impl sAIAlertnessMsg {
+    pub fn level(&self) -> std::result::Result<AIScriptAlertLevel, i32> {
+        AIScriptAlertLevel::try_from(self.level_raw)
+    }
+
+    pub fn previous_level(&self) -> std::result::Result<AIScriptAlertLevel, i32> {
+        AIScriptAlertLevel::try_from(self.previous_level_raw)
+    }
+}
+
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AIMode {
+    Asleep,
+    SuperEfficient,
+    Efficient,
+    Normal,
+    Combat,
+    Dead,
+}
+
+impl TryFrom<i32> for AIMode {
+    type Error = i32;
+    fn try_from(v: i32) -> std::result::Result<Self, Self::Error> {
+        match v {
+            0 => Ok(Self::Asleep),
+            1 => Ok(Self::SuperEfficient),
+            2 => Ok(Self::Efficient),
+            3 => Ok(Self::Normal),
+            4 => Ok(Self::Combat),
+            5 => Ok(Self::Dead),
+            _ => Err(v),
+        }
+    }
+}
+
+/// AI mode message data.
+///
+/// Received for the following messages:
+///  - AIModeChange
+#[repr(C)]
+#[derive(Copy, Clone, Debug, DarkMessageData)]
+pub struct sAIModeChangeMsg {
+    pub base: sScrMsg,
+    mode_raw: c_int,
+    previous_mode_raw: c_int,
+}
+
+impl sAIModeChangeMsg {
+    pub fn mode(&self) -> std::result::Result<AIMode, i32> {
+        AIMode::try_from(self.mode_raw)
+    }
+
+    pub fn previous_mode(&self) -> std::result::Result<AIMode, i32> {
+        AIMode::try_from(self.previous_mode_raw)
+    }
+}
+
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AIAction {
+    NoAction,
+    Goto,
+    Frob,
+    Maneuver,
+}
+
+impl TryFrom<i32> for AIAction {
+    type Error = i32;
+    fn try_from(v: i32) -> std::result::Result<Self, Self::Error> {
+        match v {
+            0 => Ok(Self::NoAction),
+            1 => Ok(Self::Goto),
+            2 => Ok(Self::Frob),
+            3 => Ok(Self::Maneuver),
+            _ => Err(v),
+        }
+    }
+}
+
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AIActionResult {
+    Done,
+    Failed,
+    NotAttempted,
+}
+
+impl TryFrom<i32> for AIActionResult {
+    type Error = i32;
+    fn try_from(v: i32) -> std::result::Result<Self, Self::Error> {
+        match v {
+            0 => Ok(Self::Done),
+            1 => Ok(Self::Failed),
+            2 => Ok(Self::NotAttempted),
+            _ => Err(v),
+        }
+    }
+}
+
+/// AI object action message data.
+///
+/// Received for the following messages:
+///  - ObjActResult
+#[repr(C)]
+#[derive(Copy, Clone, Debug, DarkMessageData)]
+pub struct sAIObjActResultMsg {
+    pub base: sScrMsg,
+    action_raw: c_int,
+    result_raw: c_int,
+    pub data: sMultiParm,
+    pub target_obj_id: ObjectId,
+}
+
+impl sAIObjActResultMsg {
+    pub fn action(&self) -> std::result::Result<AIAction, i32> {
+        AIAction::try_from(self.action_raw)
+    }
+
+    pub fn result(&self) -> std::result::Result<AIActionResult, i32> {
+        AIActionResult::try_from(self.result_raw)
+    }
+}
+
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PhysCollisionType {
+    None,
+    Terrain,
+    Object,
+}
+
+impl TryFrom<i32> for PhysCollisionType {
+    type Error = i32;
+    fn try_from(v: i32) -> std::result::Result<Self, Self::Error> {
+        match v {
+            0 => Ok(Self::None),
+            1 => Ok(Self::Terrain),
+            2 => Ok(Self::Object),
+            _ => Err(v),
+        }
+    }
+}
+
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PhysContactType {
+    None,
+    Face,
+    Edge,
+    Vertex,
+    Sphere,
+    SphereHat,
+    OBB,
+}
+
+impl TryFrom<i32> for PhysContactType {
+    type Error = i32;
+    fn try_from(v: i32) -> std::result::Result<Self, Self::Error> {
+        match v {
+            0 => Ok(Self::None),
+            1 => Ok(Self::Face),
+            2 => Ok(Self::Edge),
+            3 => Ok(Self::Vertex),
+            4 => Ok(Self::Sphere),
+            5 => Ok(Self::SphereHat),
+            6 => Ok(Self::OBB),
+            _ => Err(v),
+        }
+    }
+}
+
+/// Physics message data.
+///
+/// Received for the following messages:
+///  - PhysFellAsleep
+///  - PhysWokeUp
+///  - PhysMadePhysical
+///  - PhysMadeNonPhysical
+///  - PhysCollision
+///  - PhysContactCreate
+///  - PhysContactDestroy
+///  - PhysEnter
+///  - PhysExit
+#[repr(C)]
+#[derive(Copy, Clone, Debug, DarkMessageData)]
+pub struct sPhysMsg {
+    pub base: sScrMsg,
+    pub sub_model: c_int,
+    collision_type_raw: c_int,
+    pub collision_obj_id: ObjectId,
+    pub collision_sub_model: c_int,
+    pub collision_momentum: c_float,
+    pub collision_normal: sVector,
+    pub collision_point: sVector,
+    contact_type_raw: c_int,
+    pub contact_obj_id: ObjectId,
+    pub contact_sub_model: c_int,
+    pub trans_obj_id: ObjectId,
+    pub trans_sub_model: c_int,
+}
+
+impl sPhysMsg {
+    pub fn collision_type(&self) -> std::result::Result<PhysCollisionType, i32> {
+        PhysCollisionType::try_from(self.collision_type_raw)
+    }
+
+    pub fn contact_type(&self) -> std::result::Result<PhysContactType, i32> {
+        PhysContactType::try_from(self.contact_type_raw)
+    }
+}
+
+/// Stim message data.
+///
+/// Received for any message ending in "Stimulus".
+#[repr(C)]
+#[derive(Copy, Clone, Debug, DarkMessageData)]
+pub struct sStimMsg {
+    pub base: sScrMsg,
+    pub stimulus_obj_id: ObjectId,
+    pub intensity: c_float,
+    pub sensor_link_id: LinkId,
+    pub source_link_id: LinkId,
+}
+
+/// Report message data.
+///
+/// Received for the following messages:
+///  - ReportMessage
+#[repr(C)]
+#[derive(Copy, Clone, Debug, DarkMessageData)]
+pub struct sReportMsg {
+    pub base: sScrMsg,
+    pub warn_level: c_int,
+    pub flags: c_int,
+    pub types: c_int,
+    text_buffer_raw: *const c_char,
+}
+
+impl sReportMsg {
+    pub fn text_buffer(&self) -> String {
+        cstr_convert(self.text_buffer_raw)
+    }
+}
+
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PropertyListenMsg {
+    Modify,
+    Set,
+    Unset,
+    Load,
+    RebuildConcrete,
+    RebuildConcreteRelevant,
+    RequestFromHost,
+}
+
+impl TryFrom<i32> for PropertyListenMsg {
+    type Error = i32;
+    fn try_from(v: i32) -> std::result::Result<Self, Self::Error> {
+        match v {
+            0 => Ok(Self::Modify),
+            1 => Ok(Self::Set),
+            2 => Ok(Self::Unset),
+            3 => Ok(Self::Load),
+            4 => Ok(Self::RebuildConcrete),
+            5 => Ok(Self::RebuildConcreteRelevant),
+            6 => Ok(Self::RequestFromHost),
+            _ => Err(v),
+        }
+    }
+}
+
+/// Prop notification message data.
+///
+/// Received for the following messages:
+///  - PropNotify
+#[repr(C)]
+#[derive(Copy, Clone, Debug, DarkMessageData)]
+pub struct sPropNotifyMsg {
+    pub base: sScrMsg,
+    notify_type_raw: c_int,
+    prop_name_raw: *const c_char,
+    pub obj_id: ObjectId,
+    pub donor_obj_id: ObjectId,
+}
+
+impl sPropNotifyMsg {
+    pub fn notify_type(&self) -> std::result::Result<PropertyListenMsg, i32> {
+        PropertyListenMsg::try_from(self.notify_type_raw)
+    }
+
+    pub fn prop_name(&self) -> String {
+        cstr_convert(self.prop_name_raw)
+    }
+}
+
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ObjNotifyMsg {
+    Create,
+    Delete,
+    LoadObj,
+    BeginCreate,
+    Database,
+    Reset,
+    Load,
+    Save,
+    Default,
+    PostLoad,
+}
+
+impl TryFrom<i32> for ObjNotifyMsg {
+    type Error = i32;
+    fn try_from(v: i32) -> std::result::Result<Self, Self::Error> {
+        match v {
+            0 => Ok(Self::Create),
+            1 => Ok(Self::Delete),
+            2 => Ok(Self::LoadObj),
+            3 => Ok(Self::BeginCreate),
+            4 => Ok(Self::Database),
+            5 => Ok(Self::Reset),
+            6 => Ok(Self::Load),
+            7 => Ok(Self::Save),
+            8 => Ok(Self::Default),
+            9 => Ok(Self::PostLoad),
+            _ => Err(v),
+        }
+    }
+}
+
+/// Object notification message data.
+///
+/// Received for the following messages:
+///  - ObjNotify
+#[repr(C)]
+#[derive(Copy, Clone, Debug, DarkMessageData)]
+pub struct sObjNotifyMsg {
+    pub base: sScrMsg,
+    notify_type_raw: c_int,
+    pub obj_id: ObjectId,
+}
+
+impl sObjNotifyMsg {
+    pub fn notify_type(&self) -> std::result::Result<ObjNotifyMsg, i32> {
+        ObjNotifyMsg::try_from(self.notify_type_raw)
+    }
+}
+
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RelationListenMsg {
+    Modify,
+    Birth,
+    Death,
+    PostMortem,
+}
+
+impl TryFrom<i32> for RelationListenMsg {
+    type Error = i32;
+    fn try_from(v: i32) -> std::result::Result<Self, Self::Error> {
+        match v {
+            0 => Ok(Self::Modify),
+            1 => Ok(Self::Birth),
+            2 => Ok(Self::Death),
+            3 => Ok(Self::PostMortem),
+            _ => Err(v),
+        }
+    }
+}
+
+/// Link notification message data.
+///
+/// Received for the following messages:
+///  - LinkNotify
+#[repr(C)]
+#[derive(Copy, Clone, Debug, DarkMessageData)]
+pub struct sLinkNotifyMsg {
+    pub base: sScrMsg,
+    notify_type_raw: c_int,
+    pub link_id: LinkId,
+    pub source_obj_id: ObjectId,
+    pub destination_obj_id: ObjectId,
+}
+
+impl sLinkNotifyMsg {
+    pub fn notify_type(&self) -> std::result::Result<RelationListenMsg, i32> {
+        RelationListenMsg::try_from(self.notify_type_raw)
+    }
+}
+
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HierarchyMsgKind {
+    Added,
+    Removed,
+}
+
+impl TryFrom<i32> for HierarchyMsgKind {
+    type Error = i32;
+    fn try_from(v: i32) -> std::result::Result<Self, Self::Error> {
+        match v {
+            0 => Ok(Self::Added),
+            1 => Ok(Self::Removed),
+            _ => Err(v),
+        }
+    }
+}
+
+/// Trait notification message data.
+///
+/// Received for the following messages:
+///  - TraitNotify
+#[repr(C)]
+#[derive(Copy, Clone, Debug, DarkMessageData)]
+pub struct sTraitNotifyMsg {
+    pub base: sScrMsg,
+    notify_type_raw: c_int,
+    pub obj_id: ObjectId,
+    pub donor_obj_id: ObjectId,
+}
+
+impl sTraitNotifyMsg {
+    pub fn notify_type(&self) -> std::result::Result<HierarchyMsgKind, i32> {
+        HierarchyMsgKind::try_from(self.notify_type_raw)
+    }
+}
+
+/// Dark game mode message data.
+///
+/// This message is Thief 1/2 only.
+///
+/// Received for the following messages:
+///  - DarkGameModeChange
+#[repr(C)]
+#[derive(Copy, Clone, Debug, DarkMessageData)]
+pub struct sDarkGameModeScrMsg {
+    pub base: sScrMsg,
+    resuming_raw: c_int,
+    suspending_raw: c_int,
+}
+
+impl sDarkGameModeScrMsg {
+    pub fn resuming(&self) -> bool {
+        self.resuming_raw > 0
+    }
+
+    pub fn suspending(&self) -> bool {
+        self.suspending_raw > 0
+    }
+}
+
+/// Pick state message data.
+///
+/// This message is Thief 1/2 only.
+///
+/// Received for the following messages:
+///  - PickStateChange
+#[repr(C)]
+#[derive(Copy, Clone, Debug, DarkMessageData)]
+pub struct sPickStateScrMsg {
+    pub base: sScrMsg,
+    pub previous_state: c_int,
+    pub state: c_int,
+}
+
+/// Confirmation message data.
+///
+/// This message is System Shock 2 only.
+///
+/// Received for the following messages:
+///  - YorNDone
+#[repr(C)]
+#[derive(Copy, Clone, Debug, DarkMessageData)]
+pub struct sYorNMsg {
+    pub base: sScrMsg,
+    yes_raw: c_int,
+}
+
+impl sYorNMsg {
+    pub fn yes(&self) -> bool {
+        self.yes_raw > 0
+    }
+}
+
+/// Keypad message data.
+///
+/// This message is System Shock 2 only.
+///
+/// Received for the following messages:
+///  - KeypadDOne
+#[repr(C)]
+#[derive(Copy, Clone, Debug, DarkMessageData)]
+pub struct sKeypadMsg {
+    pub base: sScrMsg,
+    pub code: c_int,
+}

--- a/crates/kc-osm/src/services.rs
+++ b/crates/kc-osm/src/services.rs
@@ -5,6 +5,7 @@ use std::{
     str::FromStr,
 };
 
+use kc_osm_proc_macros::dark_service;
 use windows::{Win32::Foundation::S_FALSE, core::*};
 
 use crate::{IScriptMan, malloc, sMultiParm, sVector};
@@ -44,7 +45,7 @@ fn get_service<T: Interface>(script_manager: &IScriptMan) -> T {
     unsafe { script_manager.GetService(&T::IID).cast::<T>().unwrap() }
 }
 
-#[interface("F40000F4-7B74-12C3-8348-00AA00A82B51")]
+#[dark_service(ActReact)]
 unsafe trait IActReactServiceT1: IUnknown {
     fn Init(&self);
     fn End(&self);
@@ -74,7 +75,7 @@ unsafe trait IActReactServiceT1: IUnknown {
     fn Stimulate(&self, who: c_int, what: c_int, how_much: c_float, source: c_int) -> HRESULT;
 }
 
-#[interface("F40000F4-7B74-12C3-8348-00AA00A82B51")]
+#[dark_service(ActReact)]
 unsafe trait IActReactService: IUnknown {
     fn Init(&self);
     fn End(&self);
@@ -210,7 +211,7 @@ impl ActReactService {
     }
 }
 
-#[interface("D70000D7-7B57-12A6-8348-00AA00A82B51")]
+#[dark_service(Debug)]
 unsafe trait IDebugService: IUnknown {
     fn Init(&self);
     fn End(&self);
@@ -311,7 +312,7 @@ impl DebugService {
     }
 }
 
-#[interface("2B000229-7CA9-13F8-8348-00AA00A82B51")]
+#[dark_service(Engine)]
 unsafe trait IEngineService: IUnknown {
     fn Init(&self);
     fn End(&self);
@@ -599,7 +600,7 @@ impl EngineService {
     }
 }
 
-#[interface("2A000228-7CA8-13F7-8348-00AA00A82B51")]
+#[dark_service(Version)]
 unsafe trait IVersionService: IUnknown {
     fn Init(&self);
     fn End(&self);

--- a/crates/kc-osm/src/services.rs
+++ b/crates/kc-osm/src/services.rs
@@ -13,10 +13,10 @@ use crate::{IScriptMan, malloc, sMultiParm, sVector};
 static mut SERVICES: Option<&Services> = None;
 
 pub struct Services {
-    pub act_react: ActReactService,
-    pub debug: DebugService,
-    pub engine: EngineService,
-    pub version: VersionService,
+    pub act_react: Option<ActReactService>,
+    pub debug: Option<DebugService>,
+    pub engine: Option<EngineService>,
+    pub version: Option<VersionService>,
 }
 
 pub fn services() -> &'static Services {
@@ -25,24 +25,16 @@ pub fn services() -> &'static Services {
 
 pub(crate) fn services_init(script_manager: IScriptMan) {
     let services = Services {
-        act_react: ActReactService {
-            service: get_service(&script_manager),
-        },
-        debug: DebugService {
-            service: get_service(&script_manager),
-        },
-        engine: EngineService {
-            service: get_service(&script_manager),
-        },
-        version: VersionService {
-            service: get_service(&script_manager),
-        },
+        act_react: try_get_service(&script_manager).map(|s| ActReactService { service: s }),
+        debug: try_get_service(&script_manager).map(|s| DebugService { service: s }),
+        engine: try_get_service(&script_manager).map(|s| EngineService { service: s }),
+        version: try_get_service(&script_manager).map(|s| VersionService { service: s }),
     };
     unsafe { SERVICES = Some(Box::leak(Box::new(services))) };
 }
 
-fn get_service<T: Interface>(script_manager: &IScriptMan) -> T {
-    unsafe { script_manager.GetService(&T::IID).cast::<T>().unwrap() }
+fn try_get_service<T: Interface>(script_manager: &IScriptMan) -> Option<T> {
+    unsafe { script_manager.GetService(&T::IID).cast::<T>().ok() }
 }
 
 #[dark_service(ActReact)]

--- a/examples/custom_commands/src/lib.rs
+++ b/examples/custom_commands/src/lib.rs
@@ -6,15 +6,22 @@ use std::{
 use kc_osm::*;
 
 pub extern "C" fn log_cmds() {
-    let debug = &services().debug;
+    let Some(debug) = &services().debug else {
+        return;
+    };
+
     for cmd in get_all_command_infos() {
         debug.print(&format!("Command: {cmd}"));
     }
 }
 
 pub extern "C" fn echo(val: *const c_char) {
+    let Some(debug) = &services().debug else {
+        return;
+    };
+
     let msg = cstr_convert(val);
-    services().debug.print(&msg);
+    debug.print(&msg);
 }
 
 #[unsafe(no_mangle)]

--- a/examples/dialog/src/lib.rs
+++ b/examples/dialog/src/lib.rs
@@ -13,13 +13,15 @@ use kc_osm::{
 };
 
 pub extern "C" fn dialog() {
+    let Some(debug) = &services().debug else {
+        return;
+    };
+
     let items = vec!["String 1", "lorem", "ipsum", "cool right?"];
     if let Some(idx) = do_simple_menu("Simple Menu Dialog", &items) {
-        services()
-            .debug
-            .print(&format!("Selected '{}' at index {idx}", items[idx]));
+        debug.print(&format!("Selected '{}' at index {idx}", items[idx]));
     } else {
-        services().debug.print("Cancelled");
+        debug.print("Cancelled");
     }
 }
 
@@ -31,6 +33,10 @@ pub struct ManualStruct {
 }
 
 pub extern "C" fn manual_struct_editor() {
+    let Some(debug) = &services().debug else {
+        return;
+    };
+
     let mut item = ManualStruct { float: 0.0, int: 2 };
 
     let editor_desc = StructEditorDesc::new("My Struct Editor", 0);
@@ -53,9 +59,9 @@ pub extern "C" fn manual_struct_editor() {
     let item_ptr = &mut item as *mut _ as *mut c_void;
     let editor = construct_struct_editor(&editor_desc, &struct_desc, item_ptr);
     if editor.go(true) {
-        services().debug.print(&format!("{item:?}"));
+        debug.print(&format!("{item:?}"));
     } else {
-        services().debug.print("Cancelled");
+        debug.print("Cancelled");
     }
 }
 
@@ -73,6 +79,10 @@ pub struct AutoStruct {
 }
 
 pub extern "C" fn auto_struct_editor() {
+    let Some(debug) = &services().debug else {
+        return;
+    };
+
     let mut item = AutoStruct {
         float: 0.0,
         my_bool: true.into(),
@@ -81,9 +91,9 @@ pub extern "C" fn auto_struct_editor() {
     };
 
     if item.edit_struct() {
-        services().debug.print(&format!("{item:?}"));
+        debug.print(&format!("{item:?}"));
     } else {
-        services().debug.print("Cancelled");
+        debug.print("Cancelled");
     }
 }
 

--- a/examples/test_mod/src/lib.rs
+++ b/examples/test_mod/src/lib.rs
@@ -8,18 +8,26 @@ pub struct TestScript {}
 
 impl TestScript {
     pub fn on_begin_script(&self, services: &Services, _: &sScrMsg, _: &mut sMultiParm) -> HRESULT {
-        let is_editor = services.version.is_editor();
-        let (major, minor) = services.version.get_version();
-        let app_name = services.version.get_app_name(true);
-        services.debug.print(&format!("is_editor: {is_editor}"));
-        services.debug.print(&format!("app_name: {app_name}"));
-        services.debug.print(&format!("version: {major}.{minor}"));
-        services.debug.print("Wowzers");
+        let (Some(debug), Some(version)) = (&services.debug, &services.version) else {
+            return HRESULT(1);
+        };
+
+        let is_editor = version.is_editor();
+        let (major, minor) = version.get_version();
+        let app_name = version.get_app_name(true);
+        debug.print(&format!("is_editor: {is_editor}"));
+        debug.print(&format!("app_name: {app_name}"));
+        debug.print(&format!("version: {major}.{minor}"));
+        debug.print("Wowzers");
         HRESULT(1)
     }
 
     pub fn on_turn_on(&self, services: &Services, _: &sScrMsg, _: &mut sMultiParm) -> HRESULT {
-        services.debug.print("Handling TurnOn in TestScript");
+        let Some(debug) = &services.debug else {
+            return HRESULT(1);
+        };
+
+        debug.print("Handling TurnOn in TestScript");
         HRESULT(1)
     }
 }
@@ -29,8 +37,12 @@ pub struct AnotherTestScript {}
 
 impl AnotherTestScript {
     pub fn on_turn_on(&self, services: &Services, _: &sScrMsg, _: &mut sMultiParm) -> HRESULT {
-        services.debug.print("Handling TurnOn in AnotherTestScript");
-        services.debug.command("run ./cmds/TogglePhys.cmd");
+        let Some(debug) = &services.debug else {
+            return HRESULT(1);
+        };
+
+        debug.print("Handling TurnOn in AnotherTestScript");
+        debug.command("run ./cmds/TogglePhys.cmd");
         HRESULT(1)
     }
 
@@ -40,9 +52,11 @@ impl AnotherTestScript {
         _: &sFrobMsg,
         _: &mut sMultiParm,
     ) -> HRESULT {
-        services
-            .debug
-            .print("Handling FrobWorldBegin in AnotherTestScript");
+        let Some(debug) = &services.debug else {
+            return HRESULT(1);
+        };
+
+        debug.print("Handling FrobWorldBegin in AnotherTestScript");
         HRESULT(1)
     }
 }

--- a/examples/test_mod/src/lib.rs
+++ b/examples/test_mod/src/lib.rs
@@ -7,7 +7,7 @@ use std::str::FromStr;
 pub struct TestScript {}
 
 impl TestScript {
-    pub fn on_begin_script(&self, services: &Services, _msg: &sScrMsg) -> HRESULT {
+    pub fn on_begin_script(&self, services: &Services, _: &sScrMsg, _: &mut sMultiParm) -> HRESULT {
         let is_editor = services.version.is_editor();
         let (major, minor) = services.version.get_version();
         let app_name = services.version.get_app_name(true);
@@ -18,7 +18,7 @@ impl TestScript {
         HRESULT(1)
     }
 
-    pub fn on_turn_on(&self, services: &Services, _msg: &sScrMsg) -> HRESULT {
+    pub fn on_turn_on(&self, services: &Services, _: &sScrMsg, _: &mut sMultiParm) -> HRESULT {
         services.debug.print("Handling TurnOn in TestScript");
         HRESULT(1)
     }
@@ -28,13 +28,18 @@ impl TestScript {
 pub struct AnotherTestScript {}
 
 impl AnotherTestScript {
-    pub fn on_turn_on(&self, services: &Services, _msg: &sScrMsg) -> HRESULT {
+    pub fn on_turn_on(&self, services: &Services, _: &sScrMsg, _: &mut sMultiParm) -> HRESULT {
         services.debug.print("Handling TurnOn in AnotherTestScript");
         services.debug.command("run ./cmds/TogglePhys.cmd");
         HRESULT(1)
     }
 
-    pub fn on_frob_world_begin(&self, services: &Services, _msg: &sFrobMsg) -> HRESULT {
+    pub fn on_frob_world_begin(
+        &self,
+        services: &Services,
+        _: &sFrobMsg,
+        _: &mut sMultiParm,
+    ) -> HRESULT {
         services
             .debug
             .print("Handling FrobWorldBegin in AnotherTestScript");

--- a/examples/test_mod/src/lib.rs
+++ b/examples/test_mod/src/lib.rs
@@ -1,6 +1,6 @@
 use std::result::Result;
 
-use kc_osm::*;
+use kc_osm::{messages::*, *};
 use std::str::FromStr;
 
 #[dark_script(BeginScript, TurnOn)]
@@ -24,13 +24,20 @@ impl TestScript {
     }
 }
 
-#[dark_script(TurnOn)]
+#[dark_script(TurnOn, FrobWorldBegin)]
 pub struct AnotherTestScript {}
 
 impl AnotherTestScript {
     pub fn on_turn_on(&self, services: &Services, _msg: &sScrMsg) -> HRESULT {
         services.debug.print("Handling TurnOn in AnotherTestScript");
         services.debug.command("run ./cmds/TogglePhys.cmd");
+        HRESULT(1)
+    }
+
+    pub fn on_frob_world_begin(&self, services: &Services, _msg: &sFrobMsg) -> HRESULT {
+        services
+            .debug
+            .print("Handling FrobWorldBegin in AnotherTestScript");
         HRESULT(1)
     }
 }


### PR DESCRIPTION
Integrates some things from Peter's fork, splitting and reworking commits where appropriate. Re-authored with his permission.

This doesn't bring across any of his new service implementations, or game detection logic as I think the latter can be done better, and I need to think about how to best support version/game differences in the former (in his case he's only targeting latest newdark).