### PR TITLE
fix: incorrect return type on `test_mod` example entrypoint

### DIFF
--- a/examples/test_mod/src/lib.rs
+++ b/examples/test_mod/src/lib.rs
@@ -36,7 +36,7 @@ impl AnotherTestScript {
 }
 
 #[unsafe(no_mangle)]
-pub extern "Rust" fn module_init(module: &mut ScriptModule) -> Result<(), &'static str> {
+pub extern "Rust" fn module_init(module: &mut ScriptModule) -> Result<(), String> {
     module.register_script::<TestScript>();
     module.register_script::<AnotherTestScript>();
 


### PR DESCRIPTION
Got missed in a0119adc9ff51a16dd0d7f19fff6773526a77fd9